### PR TITLE
Adds support for rootDir in .clasp.json

### DIFF
--- a/index.js
+++ b/index.js
@@ -220,7 +220,7 @@ function getProjectSettings() {
       dotfile.read().then((settings) => {
         // Settings must have the script ID. Otherwise we err.
         if (settings.scriptId) {
-          resolve(settings.scriptId);
+          resolve(settings);
         } else {
           fail();
         }
@@ -388,8 +388,9 @@ program
  * Fetches the files for a project from the server and writes files locally to
  * `pwd` with dots converted to subdirectories.
  * @param {string} scriptId The project script id
+ * @param {string|null} rootDir The directory to save the project files to. Defaults to `pwd`
  */
-function fetchProject(scriptId) {
+function fetchProject(scriptId, rootDir) {
   spinner.start();
   getAPICredentials(() => {
     script.projects.getContent({
@@ -411,13 +412,13 @@ function fetchProject(scriptId) {
         let sortedFiles = res.files.sort((file) => file.name);
         sortedFiles.map((file) => {
           let filePath = `${file.name}.${getFileType(file.type)}`;
-          let truePath = `./${filePath}`;
+          let truePath = `${rootDir || '.'}/${filePath}`;
           mkdirp(path.dirname(truePath), (err) => {
             if (err) return logError(err, ERROR.FS_DIR_WRITE);
-            fs.writeFile(`./${filePath}`, file.source, (err) => {
+            fs.writeFile(truePath, file.source, (err) => {
               if (err) return logError(err, ERROR.FS_FILE_WRITE);
             });
-            console.log(`└─ ${filePath}`);
+            console.log(`└─ ${rootDir ? truePath : filePath}`); // Log only filename if pulling to root (Code.gs vs ./Code.gs)
           });
         });
       }
@@ -444,10 +445,10 @@ program
   .command('pull')
   .description('Fetch a remote project')
   .action(() => {
-    getProjectSettings().then((scriptId) => {
+    getProjectSettings().then(({scriptId, rootDir}) => {
       if (scriptId) {
         spinner.setSpinnerTitle(LOG.PULLING);
-        fetchProject(scriptId);
+        fetchProject(scriptId, rootDir);
       }
     });
   });
@@ -466,10 +467,10 @@ program
     spinner.setSpinnerTitle(LOG.PUSHING);
     spinner.start();
     getAPICredentials(() => {
-      getProjectSettings().then((scriptId) => {
+      getProjectSettings().then(({scriptId, rootDir}) => {
         if (!scriptId) return;
         // Read all filenames as a flattened tree
-        recursive(`./`, (err, filePaths) => {
+        recursive(rootDir || './', (err, filePaths) => {
           if (err) return logError(err);
           // Filter files that aren't allowed.
           filePaths = filePaths.filter((name) => !name.startsWith('.'));
@@ -482,10 +483,12 @@ program
               let nonIgnoredFilePaths = [];
               let files = filePaths.map((name, i) => {
                 let nameWithoutExt = name.slice(0, -path.extname(name).length);
+                // Formats rootDir/appsscript.json to appsscript.json. Preserves subdirectory names in rootDir
+                let formattedName = rootDir ? formattedName.slice(rootDir.length + 1, formattedName.length) : nameWithoutExt;
                 if (getAPIFileType(name) && !anymatch(ignorePatterns, name)) {
                   nonIgnoredFilePaths.push(name);
                   return {
-                    name: nameWithoutExt, // the API separates the extension
+                    name: formattedName, // the API separates the extension
                     type: getAPIFileType(name), // the file
                     source: contents[i]
                   };
@@ -525,7 +528,7 @@ program
   .command('open')
   .description('Open a script')
   .action((scriptId) => {
-    getProjectSettings().then((scriptId) => {
+    getProjectSettings().then(({scriptId}) => {
       if (scriptId) {
         console.log(LOG.OPEN_PROJECT(scriptId));
         if (scriptId.length < 30) {
@@ -545,7 +548,7 @@ program
   .description('List deployment ids of a script')
   .action(() => {
     getAPICredentials(() => {
-      getProjectSettings().then((scriptId) => {
+      getProjectSettings().then(({scriptId}) => {
         if (!scriptId) return;
         spinner.setSpinnerTitle(LOG.DEPLOYMENT_LIST(scriptId));
         spinner.start();
@@ -583,7 +586,7 @@ program
   .action((version, description) => {
     description = description || '';
     getAPICredentials(() => {
-      getProjectSettings().then((scriptId) => {
+      getProjectSettings().then(({scriptId}) => {
         if (!scriptId) return;
         spinner.setSpinnerTitle(LOG.DEPLOYMENT_START(scriptId));
         spinner.start();
@@ -640,7 +643,7 @@ program
   .description('Undeploy a deployment of a project')
   .action((deploymentId) => {
     getAPICredentials(() => {
-      getProjectSettings().then((scriptId) => {
+      getProjectSettings().then(({scriptId}) => {
         if (!scriptId) return;
         spinner.setSpinnerTitle(LOG.UNDEPLOYMENT_START(deploymentId));
         spinner.start();
@@ -668,7 +671,7 @@ program
   .description(`Update a deployment`)
   .action((deploymentId, version, description) => {
     getAPICredentials(() => {
-      getProjectSettings().then((scriptId) => {
+      getProjectSettings().then(({scriptId}) => {
         script.projects.deployments.update({
           scriptId,
           deploymentId,
@@ -701,7 +704,7 @@ program
     spinner.setSpinnerTitle('Grabbing versions...');
     spinner.start();
     getAPICredentials(() => {
-      getProjectSettings().then((scriptId) => {
+      getProjectSettings().then(({scriptId}) => {
         script.projects.versions.list({
           scriptId,
         }, {}, (error, res) => {
@@ -734,7 +737,7 @@ program
     spinner.setSpinnerTitle(LOG.VERSION_CREATE);
     spinner.start();
     getAPICredentials(() => {
-      getProjectSettings().then((scriptId) => {
+      getProjectSettings().then(({scriptId}) => {
         script.projects.versions.create({
           scriptId,
           description,

--- a/index.js
+++ b/index.js
@@ -418,7 +418,8 @@ function fetchProject(scriptId, rootDir) {
             fs.writeFile(truePath, file.source, (err) => {
               if (err) return logError(err, ERROR.FS_FILE_WRITE);
             });
-            console.log(`└─ ${rootDir ? truePath : filePath}`); // Log only filename if pulling to root (Code.gs vs ./Code.gs)
+            // Log only filename if pulling to root (Code.gs vs ./Code.gs)
+            console.log(`└─ ${rootDir ? truePath : filePath}`); 
           });
         });
       }
@@ -445,7 +446,7 @@ program
   .command('pull')
   .description('Fetch a remote project')
   .action(() => {
-    getProjectSettings().then(({scriptId, rootDir}) => {
+    getProjectSettings().then(({ scriptId, rootDir }) => {
       if (scriptId) {
         spinner.setSpinnerTitle(LOG.PULLING);
         fetchProject(scriptId, rootDir);
@@ -483,8 +484,16 @@ program
               let nonIgnoredFilePaths = [];
               let files = filePaths.map((name, i) => {
                 let nameWithoutExt = name.slice(0, -path.extname(name).length);
-                // Formats rootDir/appsscript.json to appsscript.json. Preserves subdirectory names in rootDir
-                let formattedName = rootDir ? formattedName.slice(rootDir.length + 1, formattedName.length) : nameWithoutExt;
+                // Formats rootDir/appsscript.json to appsscript.json. 
+                // Preserves subdirectory names in rootDir 
+                // (rootDir/foo/Code.js becomes foo/Code.js)
+                let formattedName = nameWithoutExt;
+                if (rootDir) {
+                  formattedName = nameWithoutExt.slice(
+                    rootDir.length + 1,
+                    nameWithoutExt.length
+                  );
+                };
                 if (getAPIFileType(name) && !anymatch(ignorePatterns, name)) {
                   nonIgnoredFilePaths.push(name);
                   return {

--- a/index.js
+++ b/index.js
@@ -256,8 +256,8 @@ function getAPICredentials(cb) {
  */
 function getFileType(type) {
   return {
-    SERVER_JS: 'js',
-    SHARED_JS: 'js'
+    SERVER_JS: 'gs',
+    SHARED_JS: 'gs'
   }[type] || type.toLowerCase();
 }
 
@@ -270,7 +270,6 @@ function getAPIFileType(path) {
   let extension = path.substr(path.lastIndexOf('.') + 1).toUpperCase();
   return {
     GS: 'SERVER_JS',
-    JS: 'SERVER_JS',
     HTML: 'HTML',
     JSON: 'JSON'
   }[extension];

--- a/index.js
+++ b/index.js
@@ -256,8 +256,8 @@ function getAPICredentials(cb) {
  */
 function getFileType(type) {
   return {
-    SERVER_JS: 'gs',
-    SHARED_JS: 'gs'
+    SERVER_JS: 'js',
+    SHARED_JS: 'js'
   }[type] || type.toLowerCase();
 }
 
@@ -270,6 +270,7 @@ function getAPIFileType(path) {
   let extension = path.substr(path.lastIndexOf('.') + 1).toUpperCase();
   return {
     GS: 'SERVER_JS',
+    JS: 'SERVER_JS',
     HTML: 'HTML',
     JSON: 'JSON'
   }[extension];

--- a/index.js
+++ b/index.js
@@ -468,7 +468,7 @@ program
     spinner.setSpinnerTitle(LOG.PUSHING);
     spinner.start();
     getAPICredentials(() => {
-      getProjectSettings().then(({scriptId, rootDir}) => {
+      getProjectSettings().then(({ scriptId, rootDir }) => {
         if (!scriptId) return;
         // Read all filenames as a flattened tree
         recursive(rootDir || './', (err, filePaths) => {
@@ -537,7 +537,7 @@ program
   .command('open')
   .description('Open a script')
   .action((scriptId) => {
-    getProjectSettings().then(({scriptId}) => {
+    getProjectSettings().then(({ scriptId }) => {
       if (scriptId) {
         console.log(LOG.OPEN_PROJECT(scriptId));
         if (scriptId.length < 30) {
@@ -557,7 +557,7 @@ program
   .description('List deployment ids of a script')
   .action(() => {
     getAPICredentials(() => {
-      getProjectSettings().then(({scriptId}) => {
+      getProjectSettings().then(({ scriptId }) => {
         if (!scriptId) return;
         spinner.setSpinnerTitle(LOG.DEPLOYMENT_LIST(scriptId));
         spinner.start();
@@ -595,7 +595,7 @@ program
   .action((version, description) => {
     description = description || '';
     getAPICredentials(() => {
-      getProjectSettings().then(({scriptId}) => {
+      getProjectSettings().then(({ scriptId }) => {
         if (!scriptId) return;
         spinner.setSpinnerTitle(LOG.DEPLOYMENT_START(scriptId));
         spinner.start();
@@ -652,7 +652,7 @@ program
   .description('Undeploy a deployment of a project')
   .action((deploymentId) => {
     getAPICredentials(() => {
-      getProjectSettings().then(({scriptId}) => {
+      getProjectSettings().then(({ scriptId }) => {
         if (!scriptId) return;
         spinner.setSpinnerTitle(LOG.UNDEPLOYMENT_START(deploymentId));
         spinner.start();
@@ -680,7 +680,7 @@ program
   .description(`Update a deployment`)
   .action((deploymentId, version, description) => {
     getAPICredentials(() => {
-      getProjectSettings().then(({scriptId}) => {
+      getProjectSettings().then(({ scriptId }) => {
         script.projects.deployments.update({
           scriptId,
           deploymentId,
@@ -713,7 +713,7 @@ program
     spinner.setSpinnerTitle('Grabbing versions...');
     spinner.start();
     getAPICredentials(() => {
-      getProjectSettings().then(({scriptId}) => {
+      getProjectSettings().then(({ scriptId }) => {
         script.projects.versions.list({
           scriptId,
         }, {}, (error, res) => {
@@ -746,7 +746,7 @@ program
     spinner.setSpinnerTitle(LOG.VERSION_CREATE);
     spinner.start();
     getAPICredentials(() => {
-      getProjectSettings().then(({scriptId}) => {
+      getProjectSettings().then(({ scriptId }) => {
         script.projects.versions.create({
           scriptId,
           description,


### PR DESCRIPTION
closes #22 

Solves for users who deploy from a non-root directory (ex. `build`) by adding support for a `rootDir` property in the project config file. This directory will be used in the `push` and `pull` commands. Defaults to the root directory when the property does not exist.