### PR TITLE
Save files as .js. Treat local .js files as SERVER_JS

### DIFF
--- a/index.js
+++ b/index.js
@@ -256,8 +256,8 @@ function getAPICredentials(cb) {
  */
 function getFileType(type) {
   return {
-    SERVER_JS: 'gs',
-    SHARED_JS: 'gs'
+    SERVER_JS: 'js',
+    SHARED_JS: 'js'
   }[type] || type.toLowerCase();
 }
 
@@ -270,6 +270,7 @@ function getAPIFileType(path) {
   let extension = path.substr(path.lastIndexOf('.') + 1).toUpperCase();
   return {
     GS: 'SERVER_JS',
+    JS: 'SERVER_JS',
     HTML: 'HTML',
     JSON: 'JSON'
   }[extension];


### PR DESCRIPTION
fixes #10 

Save `.gs` files with the `.js` extension when fetching project files. Assign type `SERVER_JS` to local `.js` files when pushing to server.