### PR TITLE
Add headless oauth support

### DIFF
--- a/index.js
+++ b/index.js
@@ -376,11 +376,7 @@ function getAPIFileType(path) {
  * @param  {string} scriptId The script ID
  */
 function saveProjectId(scriptId) {
-<<<<<<< HEAD
-  DOTFILE.PROJECT().write({scriptId}); // Save the script id
-=======
   DOTFILE.PROJECT().write({ scriptId }); // Save the script id
->>>>>>> f5967eb2726a9244895a4873334cb065c0b40e3a
 }
 
 /**
@@ -412,41 +408,8 @@ program
     DOTFILE.RC.read().then((rc) => {
       console.warn(ERROR.LOGGED_IN);
     }).catch((err) => {
-<<<<<<< HEAD
       authorize(cmd.localhost);
     })
-=======
-      var authUrl = oauth2Client.generateAuthUrl({
-        access_type: 'offline',
-        scope: [
-          'https://www.googleapis.com/auth/script.deployments',
-          'https://www.googleapis.com/auth/script.projects',
-        ],
-      });
-      console.log(LOG.AUTHORIZE(authUrl));
-      open(authUrl);
-
-      // Create a local HTTP server that reads the OAuth token
-      var app = connect();
-      app.use(function (req, res) {
-        var url_parts = url.parse(req.url, true);
-        var code = url_parts.query.code;
-        if (url_parts.query.code) {
-          oauth2Client.getToken(code, (err, token) => {
-            if (err) return console.error(ERROR.ACCESS_TOKEN + err);
-            DOTFILE.RC.write(token).then(() => {
-              // Kill the CLI after DOTFILE write
-              console.log(LOG.AUTH_SUCCESSFUL);
-              process.exit(0);
-            });
-          });
-        }
-        res.end(LOG.AUTH_PAGE_SUCCESSFUL);
-      });
-      http.createServer(app)
-        .listen(REDIRECT_PORT);
-    });
->>>>>>> f5967eb2726a9244895a4873334cb065c0b40e3a
   });
 
 /**

--- a/index.js
+++ b/index.js
@@ -47,6 +47,7 @@ const DEBUG = false;
 // Names / Paths
 const PROJECT_NAME = 'clasp';
 const PROJECT_MANIFEST_BASENAME = 'appsscript';
+const PROJECT_MANIFEST_FULLNAME = `${PROJECT_MANIFEST_BASENAME}.json`;
 
 // Dotfile names
 const DOT = {
@@ -273,6 +274,22 @@ function getAPIFileType(path) {
   }[extension];
 }
 
+/**
+ * Saves the script ID in the project dotfile.
+ * @param  {string} scriptId The script ID
+ */
+function saveProjectId(scriptId) {
+  DOTFILE.PROJECT().write({scriptId}); // Save the script id
+}
+
+/**
+ * Checks if the current directory appears to be a valid project.
+ * @return {boolean} True if valid project, false otherwise
+ */
+function manifestExists() {
+  return fs.existsSync(PROJECT_MANIFEST_FULLNAME);
+}
+
 // CLI
 
 /**
@@ -356,7 +373,10 @@ program
           } else {
             var scriptId = res.scriptId;
             console.log(LOG.CREATE_PROJECT_FINISH(scriptId));
-            fetchProject(scriptId); // fetches appsscript.json, o.w. `push` breaks
+            saveProjectId(scriptId)
+            if (!manifestExists()) {
+              fetchProject(scriptId); // fetches appsscript.json, o.w. `push` breaks
+            }
           }
         });
       });
@@ -382,7 +402,6 @@ function fetchProject(scriptId) {
           logError(error, ERROR.SCRIPT_ID);
         }
       } else {
-        DOTFILE.PROJECT().write({scriptId}); // Save the script id
         if (!res.files) {
           return logError(null, ERROR.SCRIPT_ID_INCORRECT(scriptId));
         }
@@ -411,6 +430,7 @@ program
   .description('Clone a project')
   .action((scriptId) => {
     spinner.setSpinnerTitle(LOG.CLONING);
+    saveProjectId(scriptId)
     fetchProject(scriptId);
   });
 

--- a/package.json
+++ b/package.json
@@ -34,6 +34,7 @@
     "find-parent-dir": "^0.3.0",
     "fs": "^0.0.1-security",
     "googleapis": "^24.0.0",
+    "http-shutdown": "^1.2.0",
     "mkdirp": "^0.5.1",
     "open": "^0.0.5",
     "path": "^0.12.7",

--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
     "add-on"
   ],
   "author": "Grant Timmerman",
-  "license": "Apache 2.0",
+  "license": "Apache-2.0",
   "dependencies": {
     "anymatch": "^1.3.2",
     "cli-spinner": "^0.2.6",


### PR DESCRIPTION
Adds --no-localhost option to login command + refactors auth a little.

Planning a subsequent change to upgrade the client lib & auth library to the recently released version (v25.x for client, v1.x) since the new auth library has support for code_verifier in the oauth flow which will makes things more secure.
