### PR TITLE
Remove dot from the script URL

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -148,7 +148,7 @@ const LOG = {
   AUTHORIZE: (authUrl: string) => `🔑  Authorize ${PROJECT_NAME} by visiting this url:\n${authUrl}\n`,
   CLONE_SUCCESS: (fileNum: number) => `Cloned ${fileNum} ${pluralize('files', fileNum)}.`,
   CLONING: 'Cloning files...',
-  CREATE_PROJECT_FINISH: (scriptId: string) => `Created new script: ${getScriptURL(scriptId)}.`,
+  CREATE_PROJECT_FINISH: (scriptId: string) => `Created new script: ${getScriptURL(scriptId)}`,
   CREATE_PROJECT_START: (title: string) => `Creating new script: ${title}...`,
   DEPLOYMENT_CREATE: 'Creating deployment...',
   DEPLOYMENT_DNE: 'No deployed versions of script.',


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/1344071/35775037-bdc35c56-09a6-11e8-8123-ed08d5684830.png)

If a dot is appended to the URL in the script log, the link points to a 404 page when clicked from the terminal.

```
gas: clasp create testing
Created new script: https://script.google.com/d/12..../edit.
Cloned 1 file.
└─ appsscript.json
gas: ls
appsscript.json package.json
gas:
```