### PR TITLE
Fix optional parameters notation on fetchProject

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -506,7 +506,7 @@ commander
  * @param {string?} rootDir The directory to save the project files to. Defaults to `pwd`
  * @param {number?} versionNumber The version of files to fetch.
  */
-function fetchProject(scriptId: string, rootDir = '', versionNumber: number?) {
+function fetchProject(scriptId: string, rootDir = '', versionNumber?: number) {
   spinner.start();
   getAPICredentials(async () => {
     await checkIfOnline();


### PR DESCRIPTION
Fixes an incorrect syntax of the optional third parameter of `fetchProject`, and reduces the number of TypeScript compilation errors.

See https://www.typescriptlang.org/docs/handbook/functions.html#optional-and-default-parameters

## Output of `npm run build`: 

Before this change: 

```
node_modules/@types/core-js/index.d.ts(504,5): error TS2687: All declarations of 'iterator' must have identical modifiers.
node_modules/@types/node/index.d.ts(75,14): error TS2687: All declarations of 'iterator' must have identical modifiers.
index.ts(45,13): error TS2529: Duplicate identifier 'Promise'. Compiler reserves name 'Promise' in top level scope of a module containing async functions.
index.ts(494,15): error TS2554: Expected 3 arguments, but got 1.
index.ts(509,70): error TS8020: JSDoc types can only be used inside documentation comments.
index.ts(556,7): error TS2554: Expected 3 arguments, but got 1.
index.ts(570,9): error TS2554: Expected 3 arguments, but got 2.
/usr/local/bin/clasp -> /usr/local/lib/node_modules/@google/clasp/index.js
+ @google/clasp@1.1.5
updated 1 package in 2.094s
```

After this change: 

```
node_modules/@types/core-js/index.d.ts(504,5): error TS2687: All declarations of 'iterator' must have identical modifiers.
node_modules/@types/node/index.d.ts(75,14): error TS2687: All declarations of 'iterator' must have identical modifiers.
index.ts(45,13): error TS2529: Duplicate identifier 'Promise'. Compiler reserves name 'Promise' in top level scope of a module containing async functions.
/usr/local/bin/clasp -> /usr/local/lib/node_modules/@google/clasp/index.js
+ @google/clasp@1.1.5
updated 1 package in 1.959s
```