### PR TITLE
Fix replacing only the first '\' character in path

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -633,7 +633,7 @@ commander
               const files = filePaths.map((name, i) => {
                 let nameWithoutExt = name.slice(0, -path.extname(name).length);
                 // Replace OS specific path separator to common '/' char
-                nameWithoutExt = nameWithoutExt.replace('\\', '/');
+                nameWithoutExt = nameWithoutExt.replace(/\\/g, '/');
 
                 // Formats rootDir/appsscript.json to appsscript.json.
                 // Preserves subdirectory names in rootDir


### PR DESCRIPTION
Current implementation only replace the first '\' char,
this will replace all '\\' chars in the file path