### PR TITLE
Add versionNumber as parameter to clone

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -550,11 +550,11 @@ function fetchProject(scriptId: string, rootDir = '', versionNumber?: number) {
 commander
   .command('clone <scriptId> [versionNumber]')
   .description('Clone a project')
-  .action(async (scriptId: string) => {
+  .action(async (scriptId: string, versionNumber?: number) => {
       await checkIfOnline();
       spinner.setSpinnerTitle(LOG.CLONING);
       saveProjectId(scriptId);
-      fetchProject(scriptId);
+      fetchProject(scriptId, '', versionNumber);
   });
 
 /**


### PR DESCRIPTION
My previous PR (#40) didn't use the versionNumber argument to clasp clone, so added that in now.  