### PR TITLE
Add logs function

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,6 +49,7 @@ clasp
 - `clasp version [description]`
 - `clasp versions`
 - `clasp list`
+- `clasp logs [--json] [--open]`
 
 ## How To...
 
@@ -120,6 +121,33 @@ helloworld3          (xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx)
 ```
 
 This shows your most recent 10 scripts.
+
+### See your Clasp Logs
+
+Use `clasp logs` to see the 5 most recent log messages from StackDriver. For example:
+
+```
+clasp logs
+ERROR Sat Apr 07 2018 10:58:31 GMT-0700 (PDT) myFunction      my log error
+INFO  Sat Apr 07 2018 10:58:31 GMT-0700 (PDT) myFunction      info message
+DEBUG Sat Apr 07 2018 10:58:31 GMT-0700 (PDT) myFunction      debugging now
+ERROR Sat Apr 07 2018 10:58:30 GMT-0700 (PDT) myFunction      another error
+INFO  Sat Apr 07 2018 10:58:30 GMT-0700 (PDT) myFunction      more info
+```
+
+You can also use `clasp logs --json` to see the information in JSON format.
+You can also use `clasp logs --open` to open the StackDriver logs in your browser.
+
+### [Get Project ID](#get-project-id)
+
+First, you'll need to edit your .clasp.json file to put in the Google Cloud projectId. You can find it by running clasp open then in the top click Resources -> Cloud Platform project... Copy the projectId (including the part project-id), so something like: project-id-xxxxxxxxxxxxxxxxxxx Put that in your .clasp.json file, which should now look something like:
+
+```
+  {
+    "scriptId":"14Ht4FoesbNDhRbbTMI_IyM9uQ27EXIP_p2rK8xCOECg5s9XKpHp4fh3d",
+    "projectId": "project-id-xxxxxxxxxxxxxxxxxxx"
+  }
+```
 
 ### Ignore Files
 

--- a/index.ts
+++ b/index.ts
@@ -1114,8 +1114,8 @@ commander
         process.exit(0);
       }
       const logger = new logging({ projectId });
-        logger.getEntries().then(printLogs);
-      });
+      logger.getEntries().then(printLogs);
+    });
 
   });  
 

--- a/index.ts
+++ b/index.ts
@@ -1114,7 +1114,7 @@ commander
         process.exit(0);
       }
       const logger = new logging({ projectId });
-      logger.getEntries().then(printLogs);
+        logger.getEntries().then(printLogs);
       });
 
   });  

--- a/package.json
+++ b/package.json
@@ -39,7 +39,6 @@
     "find-parent-dir": "^0.3.0",
     "fs": "^0.0.1-security",
     "googleapis": "^25.0.0",
-    "grpc": "^1.10.1",
     "http-shutdown": "^1.2.0",
     "is-online": "^7.0.0",
     "mkdirp": "^0.5.1",

--- a/package.json
+++ b/package.json
@@ -27,8 +27,10 @@
   "author": "Grant Timmerman",
   "license": "Apache-2.0",
   "dependencies": {
+    "@google-cloud/logging": "^1.2.0",
     "anymatch": "^1.3.2",
     "bluebird": "^3.5.1",
+    "chalk": "^2.3.2",
     "cli-spinner": "^0.2.6",
     "commander": "^2.11.0",
     "connect": "^3.6.5",
@@ -37,6 +39,7 @@
     "find-parent-dir": "^0.3.0",
     "fs": "^0.0.1-security",
     "googleapis": "^25.0.0",
+    "grpc": "^1.10.1",
     "http-shutdown": "^1.2.0",
     "is-online": "^7.0.0",
     "mkdirp": "^0.5.1",


### PR DESCRIPTION
Examples:

`clasp logs`
```
(ERROR)    - myFunction      - oh no                - [Sat Apr 07 2018 10:58:31 GMT-0700 (PDT)]
(INFO)     - myFunction      - new                  - [Sat Apr 07 2018 10:58:31 GMT-0700 (PDT)]
(DEBUG)    - myFunction      - suppp                - [Sat Apr 07 2018 10:58:31 GMT-0700 (PDT)]
(ERROR)    - myFunction      - oh no                - [Sat Apr 07 2018 10:58:30 GMT-0700 (PDT)]
(INFO)     - myFunction      - new                  - [Sat Apr 07 2018 10:58:30 GMT-0700 (PDT)]
```

`clasp logs --json`
```
(ERROR)    - myFunction      - {
    "timestamp": {
        "seconds": 1523123911,
        "nanos": 894999980
    },
    "labels": {
        "script.googleapis.com/process_id": "maybe secret, not sure",
        "script.googleapis.com/user_key": "super secret key",
        "script.googleapis.com/project_key": "also very secret"
    },
    "insertId": "1yhq6jdg4coamx9",
    "httpRequest": null,
    "resource": {
        "labels": {
            "function_name": "myFunction",
            "project_id": "project-id-2758325992214167277",
            "invocation_type": "editor"
        },
        "type": "app_script_function"
    },
    "severity": "ERROR",
    "logName": "projects/project-id-2758325992214167277/logs/script.googleapis.com%2Fconsole_logs",
    "operation": null,
    "trace": "",
    "sourceLocation": null,
    "receiveTimestamp": {
        "seconds": "1523123912",
        "nanos": 901087233
    },
    "textPayload": "oh no",
    "payload": "textPayload"
} - [Sat Apr 07 2018 10:58:31 GMT-0700 (PDT)]
```

(Note: it also does the most recent 5 logs for json, but I've shortened it here)

`clasp logs --open`

Opens the logs in StackDriver in the browser.


