### PR TITLE
Create clasp run V1 command

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -335,7 +335,7 @@ function authorize(useLocalhost: boolean, writeToLocalKey: boolean) {
       oauth2Client.getToken(code).then((token) => res(token.tokens));
     });
   }).then((token: object) => {
-    writeToLocalKey ? DOTFILE.RC_LOCAL.write(token) : DOTFILE.RC.write(token)
+    writeToLocalKey ? DOTFILE.RC_LOCAL.write(token) : DOTFILE.RC.write(token);
   })
     .then(() => console.log(LOG.AUTH_SUCCESSFUL))
     .catch((err: string) => console.error(ERROR.ACCESS_TOKEN + err));
@@ -1124,11 +1124,11 @@ commander
   .action((scriptId, theFunction) => {
     getAPICredentials(true, async () => {
       await checkIfOnline();
-      let params = {
+      const params = {
         'scriptId': scriptId,
         'function': theFunction,
         'devMode': false
-      }
+      };
 
       script.scripts.run(params).then(response => {
         console.log(response.data);

--- a/index.ts
+++ b/index.ts
@@ -305,7 +305,7 @@ function getAPICredentials(isLocal: boolean, cb: (rc: ClaspSettings | void) => v
  * @param {boolean} useLocalhost True if a local HTTP server should be run
  *     to handle the auth response. False if manual entry used.
  */
-function authorize(useLocalhost: boolean, writeToLocalKey: boolean) {
+function authorize(useLocalhost: boolean, writeToOwnKey: boolean) {
   const codes = oauth2Client.generateCodeVerifier();
   // See https://developers.google.com/identity/protocols/OAuth2InstalledApp#step1-code-verifier
   const options = {
@@ -327,7 +327,7 @@ function authorize(useLocalhost: boolean, writeToLocalKey: boolean) {
       oauth2Client.getToken(code).then((token) => res(token.tokens));
     });
   }).then((token: object) => {
-    writeToLocalKey ? DOTFILE.RC_LOCAL.write(token) : DOTFILE.RC.write(token);
+    writeToOwnKey ? DOTFILE.RC_LOCAL.write(token) : DOTFILE.RC.write(token);
   })
     .then(() => console.log(LOG.AUTH_SUCCESSFUL))
     .catch((err: string) => console.error(ERROR.ACCESS_TOKEN + err));

--- a/index.ts
+++ b/index.ts
@@ -133,9 +133,14 @@ const DOTFILE = {
 // API settings
 // @see https://developers.google.com/oauthplayground/
 const REDIRECT_URI_OOB = 'urn:ietf:wg:oauth:2.0:oob';
+// const oauth2Client = new OAuth2Client({
+//   clientId: '1072944905499-vm2v2i5dvn0a0d2o4ca36i1vge8cvbn0.apps.googleusercontent.com',
+//   clientSecret: 'v6V3fKV_zWU7iw1DrpO1rknX',
+//   redirectUri: 'http://localhost',
+// });
 const oauth2Client = new OAuth2Client({
-  clientId: '1072944905499-vm2v2i5dvn0a0d2o4ca36i1vge8cvbn0.apps.googleusercontent.com',
-  clientSecret: 'v6V3fKV_zWU7iw1DrpO1rknX',
+  clientId: '966757935325-0k94acvv2ardm9oudi38h5tu5nhd8d96.apps.googleusercontent.com',
+  clientSecret: 'GzcdBI57_YZAHDJ9GYeS35q9',
   redirectUri: 'http://localhost',
 });
 const script = google.script({
@@ -293,11 +298,11 @@ function getProjectSettings(failSilently?: boolean): Promise<ProjectSettings> {
 function getAPICredentials(isLocal: boolean, cb: (rc: ClaspSettings | void) => void) {
   const dotfile = isLocal ? DOTFILE.RC_LOCAL : DOTFILE.RC;
   dotfile.read().then((rc: ClaspSettings) => {
-      oauth2Client.setCredentials(rc);
-      cb(rc);
-    }).catch((err: object) => {
-      process.exit(-1);
-    });
+    oauth2Client.setCredentials(rc);
+    cb(rc);
+  }).catch((err: object) => {
+    process.exit(-1);
+  });
 }
 
 /**
@@ -1119,9 +1124,9 @@ commander
       await checkIfOnline();
       getProjectSettings().then(({ scriptId }: ProjectSettings) => {
         const params = {
-          'scriptId': scriptId,
-          'function': functionName,
-          'devMode': true
+          scriptId,
+          function: functionName,
+          devMode: true
         };
 
         script.scripts.run(params).then(response => {

--- a/index.ts
+++ b/index.ts
@@ -1107,7 +1107,7 @@ commander
  * This function runs your script in the cloud. You must supply
  * the functionName params. For now, it can 
  * only run functions that do not require other authorization.
- * @param theFunction function in the script that you want to run
+ * @param functionName function in the script that you want to run
  * @see https://developers.google.com/apps-script/api/reference/rest/v1/scripts/run
  * Note: to use this command, you must have used `clasp login --ownkey`
  */

--- a/index.ts
+++ b/index.ts
@@ -133,14 +133,9 @@ const DOTFILE = {
 // API settings
 // @see https://developers.google.com/oauthplayground/
 const REDIRECT_URI_OOB = 'urn:ietf:wg:oauth:2.0:oob';
-// const oauth2Client = new OAuth2Client({
-//   clientId: '1072944905499-vm2v2i5dvn0a0d2o4ca36i1vge8cvbn0.apps.googleusercontent.com',
-//   clientSecret: 'v6V3fKV_zWU7iw1DrpO1rknX',
-//   redirectUri: 'http://localhost',
-// });
 const oauth2Client = new OAuth2Client({
-  clientId: '966757935325-0k94acvv2ardm9oudi38h5tu5nhd8d96.apps.googleusercontent.com',
-  clientSecret: 'GzcdBI57_YZAHDJ9GYeS35q9',
+  clientId: '1072944905499-vm2v2i5dvn0a0d2o4ca36i1vge8cvbn0.apps.googleusercontent.com',
+  clientSecret: 'v6V3fKV_zWU7iw1DrpO1rknX',
   redirectUri: 'http://localhost',
 });
 const script = google.script({

--- a/index.ts
+++ b/index.ts
@@ -1121,7 +1121,7 @@ commander
         const params = {
           'scriptId': scriptId,
           'function': functionName,
-          'devMode': false
+          'devMode': true
         };
 
         script.scripts.run(params).then(response => {

--- a/package.json
+++ b/package.json
@@ -29,6 +29,7 @@
   "dependencies": {
     "@google-cloud/logging": "^1.2.0",
     "anymatch": "^1.3.2",
+    "axios": "^0.18.0",
     "chalk": "^2.3.2",
     "cli-spinner": "^0.2.6",
     "commander": "^2.11.0",
@@ -38,6 +39,7 @@
     "find-parent-dir": "^0.3.0",
     "fs": "^0.0.1-security",
     "googleapis": "^28.1.0",
+    "grpc": "^1.10.1",
     "http-shutdown": "^1.2.0",
     "is-online": "^7.0.0",
     "mkdirp": "^0.5.1",


### PR DESCRIPTION
This is what we can call V1 of `clasp run`. There are a couple of things to note for this to work:

You will need to put your `clientId` and `clientSecret` here: https://github.com/google/clasp/blob/57adf76adda47d155fa818d20cc3d88fb15aac8e/index.ts#L135

Then build the tool `sudo npm run build`

Then, use `clasp login --localkey` to login and authorize (saves `.clasprc.json` to `./` instead of `~/.`).

Then go ahead and use `clasp run <scriptId> <theFunction>`

Probably needs a bit of work, but we'll see how helpful this is for now.



Signed-off-by: campionfellin <campionfellin@gmail.com>