### PR TITLE
Fix clasp logs

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -1049,8 +1049,6 @@ commander
     open: boolean,
   }) => {
     await checkIfOnline();
-    console.log('IN DEVELOPMENT!');
-    process.exit(0);
     function printLogs([entries]:any[]) {
       for (let i = 0; i < 5; ++i) {
         const metadata = entries[i].metadata;
@@ -1082,7 +1080,7 @@ commander
       }
     }
 
-    getProjectSettings().then(({ projectId }: ProjectSettings) => {
+    getProjectSettings().then(({ scriptId, rootDir, projectId }: ProjectSettings) => {
       if (!projectId) {
         console.error(ERROR.NO_GCLOUD_PROJECT);
         process.exit(-1);
@@ -1095,10 +1093,8 @@ commander
       }
       const logger = new logging({
         projectId,
-        // auth: oauth2Client
       });
-      console.log(logger.getEntries());
-      // return logger.getEntries().then(printLogs);
+      return logger.getEntries().then(printLogs);
     });
   });
 


### PR DESCRIPTION
To run this, clone the latest version of `clasp`. Make these few changes. Now say you `clasp clone` or `clasp create` a project. (Better to use `clasp clone` with one that already has been run, as sometimes StackDriver logs take some time to update). Then when you run `clasp logs` you'll get:

```
Please set your projectId in your .clasp.json file to your Google Cloud project ID.

  You can find your projectId by following the instructions in the README here:

  https://github.com/google/clasp#get-project-id
```

Basically do `clasp open` then hit Resources -> Cloud Platform Project and copy your `project-id-xxx`

Then put it in your `.clasp.json` like so:

```
  {
    "scriptId":"14Ht4FoesbNDhRbbTMI_IyM9uQ27EXIP_p2rK8xCOECg5s9XKpHp4fh3d",
    "projectId": "project-id-xxxxxxxxxxxxxxxxxxx"
  }
```

run `clasp logs` and you should see something like:

```
ERROR Sat Apr 07 2018 10:58:31 GMT-0700 (PDT) myFunction      oh no
INFO  Sat Apr 07 2018 10:58:31 GMT-0700 (PDT) myFunction      new
DEBUG Sat Apr 07 2018 10:58:31 GMT-0700 (PDT) myFunction      suppp
ERROR Sat Apr 07 2018 10:58:30 GMT-0700 (PDT) myFunction      oh no
INFO  Sat Apr 07 2018 10:58:30 GMT-0700 (PDT) myFunction      new
```

Signed-off-by: campionfellin <campionfellin@gmail.com>