### PR TITLE
Make travis tests

### DIFF
--- a/.claspignore
+++ b/.claspignore
@@ -1,0 +1,3 @@
+**/**
+!Code.js
+!appsscript.json

--- a/.travis.yml
+++ b/.travis.yml
@@ -13,7 +13,7 @@ cache:
   directories:
   - node_modules
 before_install:
-- openssl aes-256-cbc -K $encrypted_0f9bbf7a60f4_key -iv $encrypted_0f9bbf7a60f4_iv
+- openssl aes-256-cbc -K $encrypted_9e00145939ea_key -iv $encrypted_9e00145939ea_iv
   -in .clasprc.json.enc -out .clasprc.json -d
 before_script:
 - npm install

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,17 +1,24 @@
-sudo: false
+sudo: required
 os:
-  - linux
-  - osx
+- linux
+- osx
 language: node_js
 node_js:
-  - node
-  - '9'
-  - '8'
-  - '7'
-  - '6'
-  - '5'
-  - '4'
-  
+- node
+- '9'
+- '8'
+- '7'
+- '6'
+cache:
+  directories:
+  - node_modules
+before_install:
+- openssl aes-256-cbc -K $encrypted_0f9bbf7a60f4_key -iv $encrypted_0f9bbf7a60f4_iv
+  -in .clasprc.json.enc -out .clasprc.json -d
+before_script:
+- npm install
+- npm run build
 script:
-  - npm install
-  - npm run lint
+- npm run lint
+- npm run test
+after_success: npm run coverage

--- a/index.ts
+++ b/index.ts
@@ -38,7 +38,7 @@ const commander = require('commander');
 const read = require('read-file');
 const readMultipleFiles = require('read-multiple-files');
 import * as recursive from 'recursive-readdir';
-import { Spinner } from 'cli-spinner';
+// import { Spinner } from 'cli-spinner';
 const splitLines = require('split-lines');
 import * as url from 'url';
 const readline = require('readline');
@@ -210,7 +210,7 @@ Did you provide the correct scriptId?`,
 };
 
 // Utils
-const spinner = new Spinner();
+// const spinner = new Spinner();
 
 /**
  * Logs errors to the user such as unauthenticated or permission denied
@@ -280,7 +280,7 @@ function getProjectSettings(failSilently?: boolean): Promise<ProjectSettings> {
   });
   promise.catch(err => {
     logError(err);
-    spinner.stop(true);
+    // spinner.stop(true);
   });
   return promise;
 }
@@ -587,14 +587,14 @@ commander
       logError(null, ERROR.FOLDER_EXISTS);
     } else {
       getAPICredentials(async () => {
-        spinner.setSpinnerTitle(LOG.CREATE_PROJECT_START(title)).start();
+        // spinner.setSpinnerTitle(LOG.CREATE_PROJECT_START(title)).start();
         getProjectSettings(true).then((settings: ProjectSettings) => {
           if (settings && settings.scriptId) {
             console.error(ERROR.NO_NESTED_PROJECTS);
             process.exit(1);
           }
           script.projects.create({ title, parentId }, {}).then(res => {
-            spinner.stop(true);
+            // spinner.stop(true);
             const scriptId = res.data.scriptId;
             console.log(LOG.CREATE_PROJECT_FINISH(scriptId));
             saveProjectId(scriptId);
@@ -602,7 +602,7 @@ commander
               fetchProject(scriptId); // fetches appsscript.json, o.w. `push` breaks
             }
           }).catch((error: object) => {
-            spinner.stop(true);
+            // spinner.stop(true);
             logError(error, ERROR.CREATE);
           });
         });
@@ -618,14 +618,14 @@ commander
  * @param {number?} versionNumber The version of files to fetch.
  */
 function fetchProject(scriptId: string, rootDir = '', versionNumber?: number) {
-  spinner.start();
+  // spinner.start();
   getAPICredentials(async () => {
     await checkIfOnline();
     script.projects.getContent({
       scriptId,
       versionNumber,
     }, {}, (error: any, { data }: any) => {
-      spinner.stop(true);
+      // spinner.stop(true);
       if (error) {
         if (error.statusCode === 404) return logError(null, ERROR.SCRIPT_ID_INCORRECT(scriptId));
         return logError(error, ERROR.SCRIPT_ID);
@@ -662,7 +662,7 @@ commander
   .description('Clone a project')
   .action(async (scriptId: string, versionNumber?: number) => {
       await checkIfOnline();
-      spinner.setSpinnerTitle(LOG.CLONING);
+      // spinner.setSpinnerTitle(LOG.CLONING);
       saveProjectId(scriptId);
       fetchProject(scriptId, '', versionNumber);
   });
@@ -677,7 +677,7 @@ commander
     await checkIfOnline();
     getProjectSettings().then(({ scriptId, rootDir }: ProjectSettings) => {
       if (scriptId) {
-        spinner.setSpinnerTitle(LOG.PULLING);
+        // spinner.setSpinnerTitle(LOG.PULLING);
         fetchProject(scriptId, rootDir);
       }
     });
@@ -695,21 +695,21 @@ commander
   .description('Update the remote project')
   .action(async () => {
     await checkIfOnline();
-    spinner.setSpinnerTitle(LOG.PUSHING).start();
+    // spinner.setSpinnerTitle(LOG.PUSHING).start();
     getAPICredentials(async () => {
       getProjectSettings().then(({ scriptId, rootDir }: ProjectSettings) => {
         if (!scriptId) return;
         getProjectFiles(rootDir, (err, projectFiles, files) => {
           if(err) {
             console.log(err);
-            spinner.stop(true);
+            // spinner.stop(true);
           } else if (projectFiles) {
             const [nonIgnoredFilePaths, ignoredFilePaths] = projectFiles;
             script.projects.updateContent({
               scriptId,
               resource: { files }
             }, {}, (error: any, res: Function) => {
-              spinner.stop(true);
+              // spinner.stop(true);
               if (error) {
                 console.error(LOG.PUSH_FAILURE);
                 error.errors.map((err: any) => {
@@ -795,11 +795,11 @@ commander
     getAPICredentials(async () => {
       getProjectSettings().then(({ scriptId }: ProjectSettings) => {
         if (!scriptId) return;
-        spinner.setSpinnerTitle(LOG.DEPLOYMENT_LIST(scriptId)).start();
+        // spinner.setSpinnerTitle(LOG.DEPLOYMENT_LIST(scriptId)).start();
         script.projects.deployments.list({
           scriptId
         }, {}, (error: any, { data }: any) => {
-          spinner.stop(true);
+          // spinner.stop(true);
           if (error) {
             logError(error);
           } else {
@@ -833,9 +833,9 @@ commander
     getAPICredentials(() => {
       getProjectSettings().then(({ scriptId }: ProjectSettings) => {
         if (!scriptId) return;
-        spinner.setSpinnerTitle(LOG.DEPLOYMENT_START(scriptId)).start();
+        // spinner.setSpinnerTitle(LOG.DEPLOYMENT_START(scriptId)).start();
         function createDeployment(versionNumber: string) {
-          spinner.setSpinnerTitle(LOG.DEPLOYMENT_CREATE);
+          // spinner.setSpinnerTitle(LOG.DEPLOYMENT_CREATE);
           script.projects.deployments.create({
             scriptId,
             resource: {
@@ -844,7 +844,7 @@ commander
               description,
             }
           }, {}, (err: any, { data }: any) => {
-            spinner.stop(true);
+            // spinner.stop(true);
             if (err) {
               console.error(ERROR.DEPLOYMENT_COUNT);
             } else {
@@ -864,7 +864,7 @@ commander
             scriptId,
             resource: versionRequestBody
           }, {}, (err: any, { data }: any) => {
-            spinner.stop(true);
+            // spinner.stop(true);
             if (err) {
               logError(null, ERROR.ONE_DEPLOYMENT_CREATE);
             } else {
@@ -889,12 +889,12 @@ commander
     getAPICredentials(() => {
       getProjectSettings().then(({ scriptId }: ProjectSettings) => {
         if (!scriptId) return;
-        spinner.setSpinnerTitle(LOG.UNDEPLOYMENT_START(deploymentId)).start();
+        // spinner.setSpinnerTitle(LOG.UNDEPLOYMENT_START(deploymentId)).start();
         script.projects.deployments.delete({
           scriptId,
           deploymentId,
         }, {}, (err: any, res: any) => {  // TODO remove any
-          spinner.stop(true);
+          // spinner.stop(true);
           if (err) {
             logError(null, ERROR.READ_ONLY_DELETE);
           } else {
@@ -926,7 +926,7 @@ commander
             }
           }
         }, {}, (error: any, res: any) => { // TODO remove any
-          spinner.stop(true);
+          // spinner.stop(true);
           if (error) {
             logError(null, error); // TODO prettier error
           } else {
@@ -945,13 +945,13 @@ commander
   .description('List versions of a script')
   .action(async () => {
     await checkIfOnline();
-    spinner.setSpinnerTitle('Grabbing versions...').start();
+    // spinner.setSpinnerTitle('Grabbing versions...').start();
     getAPICredentials(() => {
       getProjectSettings().then(({ scriptId }: ProjectSettings) => {
         script.projects.versions.list({
           scriptId,
         }, {}, (error: any, { data }: any) => {
-          spinner.stop(true);
+          // spinner.stop(true);
           if (error) {
             logError(error);
           } else {
@@ -978,14 +978,14 @@ commander
   .description('Creates an immutable version of the script')
   .action(async (description: string) => {
     await checkIfOnline();
-    spinner.setSpinnerTitle(LOG.VERSION_CREATE).start();
+    // spinner.setSpinnerTitle(LOG.VERSION_CREATE).start();
     getAPICredentials(async () => {
       getProjectSettings().then(({ scriptId }: ProjectSettings) => {
         script.projects.versions.create({
           scriptId,
           description,
         }, {}, (error: any, { data }: any) => {
-          spinner.stop(true);
+          // spinner.stop(true);
           if (error) {
             logError(error);
           } else {
@@ -993,7 +993,7 @@ commander
           }
         });
       }).catch((err: any) => {
-        spinner.stop(true);
+        // spinner.stop(true);
         logError(err);
       });
     });
@@ -1013,7 +1013,7 @@ commander
   .description('List App Scripts projects')
   .action(async () => {
     await checkIfOnline();
-    spinner.setSpinnerTitle(LOG.FINDING_SCRIPTS).start();
+    // spinner.setSpinnerTitle(LOG.FINDING_SCRIPTS).start();
     getAPICredentials(async () => {
       const drive = google.drive({version: 'v3', auth: oauth2Client});
       const res = await drive.files.list({
@@ -1021,7 +1021,7 @@ commander
         fields: 'nextPageToken, files(id, name)',
         q: "mimeType='application/vnd.google-apps.script'",
       });
-      spinner.stop(true);
+      // spinner.stop(true);
       const files = res.data.files;
       if (files.length) {
         files.map((file: any) => {

--- a/package.json
+++ b/package.json
@@ -6,7 +6,8 @@
   "scripts": {
     "build": "rm index.js; tsc --project tsconfig.json; sudo npm i -g;",
     "lint": "tslint -c tslint.json index.ts",
-    "test": "sh test.sh"
+    "test": "nyc --cache false mocha --timeout 100000",
+    "coverage": "nyc --cache false report --reporter=text-lcov | coveralls"
   },
   "bin": {
     "clasp": "./index.js"
@@ -66,6 +67,10 @@
     "@types/open": "^0.0.29",
     "@types/pluralize": "^0.0.28",
     "@types/recursive-readdir": "^2.2.0",
+    "chai": "^4.1.2",
+    "coveralls": "^3.0.0",
+    "mocha": "^5.1.0",
+    "nyc": "^11.6.0",
     "tslint": "^5.9.1",
     "typescript": "^2.8.1"
   }

--- a/test/test.js
+++ b/test/test.js
@@ -1,0 +1,143 @@
+const expect = require('chai').expect;
+const spawnSync = require('child_process').spawnSync;
+fs = require('fs');
+
+describe('Test help for each function', () => {
+    
+    it('should output help for run command', () => {
+        const result = spawnSync(
+            'clasp', ['run', '--help'], { encoding : 'utf8' }
+        );
+        
+        expect(result.status).to.equal(0);
+        expect(result.stdout).to.include('Run a function in your Apps Scripts project');
+    });
+
+    it('should output help for logs command', () => {
+        const result = spawnSync(
+            'clasp', ['logs', '--help'], { encoding : 'utf8', detached: true }
+        );
+        
+        expect(result.status).to.equal(0);
+        expect(result.stdout).to.include('Shows the StackDriver Logs');
+    });
+
+});
+
+
+describe('Test clasp list', () => {
+
+    it('should list clasp projects correctly', () => {
+        const result = spawnSync(
+            'clasp', ['list'], { encoding : 'utf8' }
+         );
+        //at least one project exists (all projects begin with this URL)
+        expect(result.stdout).to.contain('https://script.google.com/d/');
+        expect(result.status).to.equal(0);
+    });
+
+});
+
+describe.skip('Test clasp create', () => {
+
+    it('should create new Untitled project correctly', () => {
+        spawnSync('rm', ['.clasp.json']);
+            const result = spawnSync(
+                'clasp', ['create'], { encoding : 'utf8' }
+            );
+    
+        expect(result.stdout).to.contain('Created new script: https://script.google.com/d/')
+        expect(result.status).to.equal(0);
+     });
+});
+
+describe('Test clasp clone', () => {
+
+    //make sure to set the CLONE_ID in Travis
+    it('should clone project correctly', () => {
+        const result = spawnSync(
+            'clasp', ['clone', process.env.CLONE_ID], { encoding : 'utf8' }
+        );
+
+        expect(result.stdout).to.contain('Cloned');
+        expect(result.stdout).to.contain('files.');
+        expect(result.status).to.equal(0);
+    });
+
+});
+
+describe('Test clasp pull', () => {
+
+    //Should use current project
+    it('should pull correctly', () => {
+        const result = spawnSync(
+            'clasp', ['pull'], { encoding : 'utf8' }
+        );
+        expect(result.stdout).to.contain('Cloned');
+        expect(result.stdout).to.contain('files.');
+        expect(result.status).to.equal(0);
+    });
+
+});
+
+describe('Test clasp push', () => {
+    //must have .claspignore (to ignore index.js and whatnot)
+    it('should push correctly', () => {
+        const result = spawnSync(
+            'clasp', ['push'], { encoding : 'utf8' }
+        );
+        expect(result.stdout).to.contain('Pushed');
+        expect(result.stdout).to.contain('files.');
+        expect(result.status).to.equal(0);
+    });
+});
+
+//skipping this because it opens web page
+describe.skip('Test clasp open', () => {
+    it('should open correctly', () => {
+        const result = spawnSync(
+            'clasp', ['open'], { encoding : 'utf8' }
+        );
+        expect(result.status).to.equal(0);
+    });
+});
+
+describe('Test clasp deployments', () => {
+    it('should list deployments correctly', () => {
+        const result = spawnSync(
+            'clasp', ['deployments'], { encoding : 'utf8' }
+        );
+        expect(result.status).to.equal(0);
+    });
+});
+
+describe('Test clasp deploy', () => {
+    it('should deploy correctly', () => {
+        const result = spawnSync(
+            'clasp', ['deploy'], { encoding : 'utf8' }
+        );
+        expect(result.stdout).to.contain('Created version ');
+        expect(result.status).to.equal(0);
+    });
+});
+
+//this must come last or be skipped because it deletes the
+//credentials
+describe.skip('Test clasp logout', () => {
+
+  it('should logout correctly', async () => {
+      const result = spawnSync(
+        'clasp', ['logout'], { encoding : 'utf8' }
+      );
+      expect(result.status).to.equal(0);
+      expect(result.stdout).to.include('You are logged out now.');
+
+      const dotExists = fs.existsSync('/.clasprc.json');
+      expect(dotExists).to.equal(false);
+    });
+    
+});
+
+
+
+


### PR DESCRIPTION
Starting to write some tests, these gives us ~50% code coverage.

The tests will fail unless you do some setup on the backend:

run `clasp login --ownkey` to generate a `.clasprc.json` file in the directory that Clasp is in. 
```
gem install travis
travis login
travis encrypt-file .clasprc.json --add
```
Now commit the file `.clasprc.json.enc` and '.travis.yml`

Also, on the backend of Travis, set the env variable CLONE_ID to a project that already exists (to test the clone function).

For code coverage (runs after tests) set up the Repo here: https://coveralls.io/

I may be forgetting some steps here, just ping me on Monday if you have any questions.



Signed-off-by: campionfellin <campionfellin@gmail.com>