### PR TITLE
Re-format .travis.yml

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,4 @@
-sudo: false
+sudo: required
 os:
   - linux
   - osx
@@ -9,9 +9,13 @@ node_js:
   - '8'
   - '7'
   - '6'
-  - '5'
-  - '4'
-  
-script:
+cache:
+  directories:
+  - node_modules
+before_script:
   - npm install
+  - npm run build
+script:
   - npm run lint
+  - npm run test
+after_success: npm run coverage


### PR DESCRIPTION
Adds `node_modules` to cache, so it won't reinstall unless there are new ones to add.
Removes node versions < 6
Installs and builds before linting/testing
After testing runs coverage report


Signed-off-by: campionfellin <campionfellin@gmail.com>