### PR TITLE
Add basic help tests as examples

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,9 +4,10 @@
   "description": "Develop Apps Script Projects locally",
   "main": "index.js",
   "scripts": {
-    "build": "rm index.js; tsc --project tsconfig.json; sudo npm i -g;",
+    "build": "tsc --project tsconfig.json; sudo npm i -g;",
     "lint": "tslint -c tslint.json index.ts",
-    "test": "sh test.sh"
+    "test": "nyc --cache false mocha --timeout 100000",
+    "coverage": "nyc --cache false report --reporter=text-lcov | coveralls"
   },
   "bin": {
     "clasp": "./index.js"
@@ -66,6 +67,10 @@
     "@types/open": "^0.0.29",
     "@types/pluralize": "^0.0.28",
     "@types/recursive-readdir": "^2.2.0",
+    "chai": "^4.1.2",
+    "coveralls": "^3.0.0",
+    "mocha": "^5.1.0",
+    "nyc": "^11.6.0",
     "tslint": "^5.9.1",
     "typescript": "^2.8.1"
   }

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "Develop Apps Script Projects locally",
   "main": "index.js",
   "scripts": {
-    "build": "tsc --project tsconfig.json; sudo npm i -g;",
+    "build": "tsc --project tsconfig.json; npm i -g;",
     "lint": "tslint -c tslint.json index.ts",
     "test": "nyc --cache false mocha --timeout 100000",
     "coverage": "nyc --cache false report --reporter=text-lcov | coveralls"

--- a/test/test.js
+++ b/test/test.js
@@ -1,0 +1,27 @@
+const expect = require('chai').expect;
+const spawnSync = require('child_process').spawnSync;
+
+describe('Test help for each function', () => {
+    
+    it('should output help for run command', () => {
+        const result = spawnSync(
+            'clasp', ['run', '--help'], { encoding : 'utf8' }
+        );
+        
+        expect(result.status).to.equal(0);
+        expect(result.stdout).to.include('Run a function in your Apps Scripts project');
+    });
+
+    it('should output help for logs command', () => {
+        const result = spawnSync(
+            'clasp', ['logs', '--help'], { encoding : 'utf8', detached: true }
+        );
+        
+        expect(result.status).to.equal(0);
+        expect(result.stdout).to.include('Shows the StackDriver Logs');
+    });
+
+});
+
+
+


### PR DESCRIPTION
Adds necessary testing libraries to the dev dependencies.
Adds `npm test` and `npm coverage` scripts to package.json
Edits `npm build` script to not remove `index.js`
Edits `npm build` script to remove the `sudo` part, as `sudo` is now required in the `.travis.yml` file.

Creates 2 tests that check the `help` command for `clasp run --help` and `clasp logs --help`. These give ~10% code coverage and are meant as examples for further tests.

See this build for testing output:

https://travis-ci.org/campionfellin/clasp/builds/367490854

Signed-off-by: campionfellin <campionfellin@gmail.com>