### PR TITLE
Convert tests to typescript

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,5 @@
 *.js
-!tests/*.js
+!tests/*.ts
 *.DS_Store
 *.log
 npm-debug.log*

--- a/tests/test.js
+++ b/tests/test.js
@@ -18,24 +18,51 @@ describe('Test help for each function', () => {
   });
 });
 
+describe('Test clasp list function', () => {
+  it('should list clasp projects correctly', () => {
+    const result = spawnSync(
+      'clasp', ['list'], { encoding: 'utf8' }
+    );
+    // Every project starts with this base URL, thus
+    // using clasp list should at least contain this
+    // in its output.
+    expect(result.stdout).to.contain('https://script.google.com/d/');
+    expect(result.status).to.equal(0);
+  });
+});
+
+describe('Test clasp create function', () => {
+  it('should create a new project correctly', () => {
+    spawnSync('rm', ['.clasp.json']);
+    const result = spawnSync(
+      'clasp', ['create'], { encoding: 'utf8' }
+    );
+    expect(result.stdout).to.contain('Created new script: https://script.google.com/d/');
+    expect(result.status).to.equal(0);
+  });
+});
+
+
 /**
 TODO: Test these commands and configs.
 
 # Commands:
-clasp;
-clasp login';
-clasp login --no-localhost;
-clasp logout;
-clasp create "myTitle"
-clasp clone <scriptId>
-clasp pull
-echo '// test' >> index.js && clasp push
-clasp open
-clasp deployments
-clasp deploy [version] [description]
-clasp redeploy <deploymentId> <version> <description>
-clasp version [description]
-clasp versions
+[ ] clasp;
+[ ] clasp login';
+[ ] clasp login --no-localhost;
+[ ] clasp logout;
+[ ] clasp create "myTitle"
+[x] clasp create <untitled>
+[x] clasp list
+[ ] clasp clone <scriptId>
+[ ] clasp pull
+[ ] echo '// test' >> index.js && clasp push
+[ ] clasp open
+[ ] clasp deployments
+[ ] clasp deploy [version] [description]
+[ ] clasp redeploy <deploymentId> <version> <description>
+[ ] clasp version [description]
+[ ] clasp versions
 
 # Configs
 - .js and .gs files

--- a/tests/test.js
+++ b/tests/test.js
@@ -18,7 +18,7 @@ describe('Test help for each function', () => {
   });
 });
 
-describe('Test clasp list function', () => {
+describe.skip('Test clasp list function', () => {
   it('should list clasp projects correctly', () => {
     const result = spawnSync(
       'clasp', ['list'], { encoding: 'utf8' }
@@ -31,7 +31,7 @@ describe('Test clasp list function', () => {
   });
 });
 
-describe('Test clasp create function', () => {
+describe.skip('Test clasp create function', () => {
   it('should create a new project correctly', () => {
     spawnSync('rm', ['.clasp.json']);
     const result = spawnSync(

--- a/tests/test.ts
+++ b/tests/test.ts
@@ -42,29 +42,27 @@ describe.skip('Test clasp create function', () => {
   });
 });
 
-
 /**
-TODO: Test these commands and configs.
-
-# Commands:
-[ ] clasp;
-[ ] clasp login';
-[ ] clasp login --no-localhost;
-[ ] clasp logout;
-[ ] clasp create "myTitle"
-[x] clasp create <untitled>
-[x] clasp list
-[ ] clasp clone <scriptId>
-[ ] clasp pull
-[ ] echo '// test' >> index.js && clasp push
-[ ] clasp open
-[ ] clasp deployments
-[ ] clasp deploy [version] [description]
-[ ] clasp redeploy <deploymentId> <version> <description>
-[ ] clasp version [description]
-[ ] clasp versions
-
-# Configs
-- .js and .gs files
-- Ignored files
-*/
+ * TODO: Test these commands and configs.
+ * 
+ * # Commands:
+ * [ ] clasp;
+ * [ ] clasp login';
+ * [ ] clasp login --no-localhost;
+ * [ ] clasp logout;
+ * [ ] clasp create "myTitle"
+ * [x] clasp create <untitled>
+ * [x] clasp list
+ * [ ] clasp clone <scriptId>
+ * [ ] clasp pull
+ * [ ] echo '// test' >> index.js && clasp push
+ * [ ] clasp open
+ * [ ] clasp deployments
+ * [ ] clasp deploy [version] [description]
+ * [ ] clasp redeploy <deploymentId> <version> <description>
+ * [ ] clasp version [description]
+ * [ ] clasp versions
+ * # Configs
+ * - .js and .gs files
+ * - Ignored files
+ */

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -10,6 +10,7 @@
   },
   "moduleResolution": "node",
   "files": [
-    "index.ts"
+    "index.ts",
+    "tests/test.ts"
   ]
 }


### PR DESCRIPTION
This PR converts our test files to Typescript so that they can be linted. Also fixes some of the linting errors that were present.

This should be merged after PR https://github.com/google/clasp/pull/114