### PR TITLE
Add clasp push and clasp open tests

### DIFF
--- a/tests/test.ts
+++ b/tests/test.ts
@@ -68,7 +68,7 @@ describe.skip('Test clasp pull function', () => {
 });
 
 describe.skip('Test clasp push function', () => {
-  it('should push a local project correctly', () => {
+  it('should push local project correctly', () => {
     fs.writeFileSync('.claspignore', '**/**\n!Code.js\n!appsscript.json');
     const result = spawnSync(
       'clasp', ['push'], { encoding: 'utf8' }

--- a/tests/test.ts
+++ b/tests/test.ts
@@ -67,6 +67,28 @@ describe.skip('Test clasp pull function', () => {
   });
 });
 
+describe.skip('Test clasp push function', () => {
+  it('should push a local project correctly', () => {
+    fs.writeFileSync('.claspignore', '**/**\n!Code.js\n!appsscript.json');
+    const result = spawnSync(
+      'clasp', ['push'], { encoding: 'utf8' }
+    );
+    expect(result.stdout).to.contain('Pushed');
+    expect(result.stdout).to.contain('files.');
+    expect(result.status).to.equal(0);
+  });
+});
+
+describe.skip('Test clasp open function', () => {
+  it('should open a project correctly', () => {
+    const result = spawnSync(
+      'clasp', ['open'], { encoding: 'utf8' }
+    );
+    //should open a browser with the project
+    expect(result.status).to.equal(0);
+  });
+});
+
 /**
  * TODO: Test these commands and configs.
  *
@@ -80,8 +102,9 @@ describe.skip('Test clasp pull function', () => {
  * [x] clasp list
  * [x] clasp clone <scriptId>
  * [x] clasp pull
+ * [x] clasp push
  * [ ] echo '// test' >> index.js && clasp push
- * [ ] clasp open
+ * [x] clasp open
  * [ ] clasp deployments
  * [ ] clasp deploy [version] [description]
  * [ ] clasp redeploy <deploymentId> <version> <description>


### PR DESCRIPTION
No issue, just adds more tests, related to this old PR: https://github.com/google/clasp/pull/110

- [x] `npm run test` succeeds.
```
-------------|----------|----------|----------|----------|-------------------|
File         |  % Stmts | % Branch |  % Funcs |  % Lines | Uncovered Line #s |
-------------|----------|----------|----------|----------|-------------------|
All files    |    47.87 |    33.91 |    48.08 |    49.07 |                   |
 clasp       |    43.97 |    33.91 |    44.04 |    44.86 |                   |
  index.js   |    43.97 |    33.91 |    44.04 |    44.86 |... 1286,1295,1299 |
 clasp/tests |      100 |      100 |      100 |      100 |                   |
  test.js    |      100 |      100 |      100 |      100 |                   |
-------------|----------|----------|----------|----------|-------------------|
```
- [x] Appropriate changes to README are included in PR.
