### PR TITLE
Add test for clasp create <title>

### DIFF
--- a/tests/test.ts
+++ b/tests/test.ts
@@ -44,6 +44,17 @@ describe.skip('Test clasp create function', () => {
   });
 });
 
+describe.skip('Test clasp create <title> function', () => {
+  it('should create a new project named <title> correctly', () => {
+    spawnSync('rm', ['.clasp.json']);
+    const result = spawnSync(
+      'clasp', ['create', 'myTitle'], { encoding: 'utf8' }
+    );
+    expect(result.stdout).to.contain('Created new script: https://script.google.com/d/');
+    expect(result.status).to.equal(0);
+  });
+});
+
 describe.skip('Test clasp clone function', () => {
   it('should clone an existing project correctly', () => {
     const settings = JSON.parse(fs.readFileSync('.clasp.json', 'utf8'));
@@ -97,7 +108,7 @@ describe.skip('Test clasp open function', () => {
  * [ ] clasp login';
  * [ ] clasp login --no-localhost;
  * [ ] clasp logout;
- * [ ] clasp create "myTitle"
+ * [x] clasp create "myTitle"
  * [x] clasp create <untitled>
  * [x] clasp list
  * [x] clasp clone <scriptId>


### PR DESCRIPTION
This keeps coverage about the same, but checks another one off the list

Signed-off-by: campionfellin <campionfellin@gmail.com>

Fixes #<issue_number_goes_here> (it's a good idea to open an issue first for discussion)

- [x] `npm run test` succeeds.
```
-------------|----------|----------|----------|----------|-------------------|
File         |  % Stmts | % Branch |  % Funcs |  % Lines | Uncovered Line #s |
-------------|----------|----------|----------|----------|-------------------|
All files    |    48.31 |    34.26 |    48.57 |    49.54 |                   |
 clasp       |    43.97 |    34.26 |    44.04 |    44.86 |                   |
  index.js   |    43.97 |    34.26 |    44.04 |    44.86 |... 1286,1295,1299 |
 clasp/tests |      100 |      100 |      100 |      100 |                   |
  test.js    |      100 |      100 |      100 |      100 |                   |
-------------|----------|----------|----------|----------|-------------------|
```
- [x] Appropriate changes to README are included in PR.
