### PR TITLE
Adds clasp logout test

### DIFF
--- a/tests/test.ts
+++ b/tests/test.ts
@@ -100,6 +100,20 @@ describe.skip('Test clasp open function', () => {
   });
 });
 
+// Fails when you logged in using --ownkey flag
+describe.skip('Test clasp logout function', () => {
+  it('should logout correctly', () => {
+    const result = spawnSync(
+      'clasp', ['logout'], { encoding: 'utf8' }
+    );
+    expect(result.status).to.equal(0);
+    const localDotExists = fs.existsSync('.clasprc.json');
+    expect(localDotExists).to.equal(false);
+    const dotExists = fs.existsSync('~/.clasprc.json');
+    expect(dotExists).to.equal(false);
+  });
+});
+
 /**
  * TODO: Test these commands and configs.
  *
@@ -107,7 +121,7 @@ describe.skip('Test clasp open function', () => {
  * [ ] clasp;
  * [ ] clasp login';
  * [ ] clasp login --no-localhost;
- * [ ] clasp logout;
+ * [x] clasp logout;
  * [x] clasp create "myTitle"
  * [x] clasp create <untitled>
  * [x] clasp list

--- a/tests/test.ts
+++ b/tests/test.ts
@@ -103,6 +103,8 @@ describe.skip('Test clasp open function', () => {
 // Fails when you logged in using --ownkey flag
 describe.skip('Test clasp logout function', () => {
   it('should logout correctly', () => {
+    fs.writeFileSync('.clasprc.json', ' ');
+    fs.writeFileSync('~.clasprc.json', ' ');
     const result = spawnSync(
       'clasp', ['logout'], { encoding: 'utf8' }
     );

--- a/tests/test.ts
+++ b/tests/test.ts
@@ -104,7 +104,7 @@ describe.skip('Test clasp open function', () => {
 describe.skip('Test clasp logout function', () => {
   it('should logout correctly', () => {
     fs.writeFileSync('.clasprc.json', ' ');
-    fs.writeFileSync('~.clasprc.json', ' ');
+    fs.writeFileSync('~/.clasprc.json', ' ');
     const result = spawnSync(
       'clasp', ['logout'], { encoding: 'utf8' }
     );


### PR DESCRIPTION
Note: this test will fail if you login using clasp login --ownkey

See issue: https://github.com/google/clasp/issues/124

This doesn't fix it, but is related.

Signed-off-by: campionfellin <campionfellin@gmail.com>

- [x] `npm run test` succeeds.
- [x] Appropriate changes to README are included in PR.
