### PR TITLE
Fix language identification of .ts files

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,3 @@
+# Override for linguist treating .ts files as js if there's a shebang on the
+# first line (https://github.com/github/linguist/issues/3733#issuecomment-317342874)
+*.ts linguist-language=TypeScript


### PR DESCRIPTION
This is a nitpicky fix for Github misidentifying `index.ts` as a javascript file:
![image](https://user-images.githubusercontent.com/384556/39080898-590c1f4c-44ec-11e8-925c-f95f64cb9bda.png).

I tested with linguist locally (https://github.com/github/linguist#application-usage) to confirm that this change fixes the issue.