### PR TITLE
Fixes unhandled rejection in clasp logs

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -190,6 +190,7 @@ Forgot ${PROJECT_NAME} commands? Get help:\n  ${PROJECT_NAME} --help`,
   FS_FILE_WRITE: 'Could not write file.',
   LOGGED_IN: `You seem to already be logged in. Did you mean to 'logout'?`,
   LOGGED_OUT: `\nCommand failed. Please login. (${PROJECT_NAME} login)`,
+  LOGS_UNAVAILABLE: 'StackDriver logs are getting ready, try again soon.',
   OFFLINE: 'Error: Looks like you are offline.',
   ONE_DEPLOYMENT_CREATE: 'Currently just one deployment can be created at a time.',
   NO_FUNCTION_NAME: 'N/A',
@@ -1071,9 +1072,10 @@ commander
         let coloredSeverity = ({
           ERROR: chalk.red(severity),
           INFO: chalk.blue(severity),
-          DEBUG: chalk.yellow(severity)
+          DEBUG: chalk.yellow(severity),
+          NOTICE: chalk.magenta(severity)
         })[severity] || severity;
-        coloredSeverity = String(coloredSeverity).padEnd(15);
+        coloredSeverity = String(coloredSeverity).padEnd(20);
         console.log(`${coloredSeverity} ${timestamp} ${functionName} ${payloadData}`);
       }
     }
@@ -1092,7 +1094,9 @@ commander
       const logger = new logging({
         projectId,
       });
-      return logger.getEntries().then(printLogs);
+      return logger.getEntries().then(printLogs).catch((err) => {
+        console.error(ERROR.LOGS_UNAVAILABLE);
+      });
     });
   });
 


### PR DESCRIPTION
Does this by catching the error and logging an appropriate message for the user.

The error that it catches looks like:

```
{ Error: 8 RESOURCE_EXHAUSTED: Insufficient tokens for quota 'logging.googleapis.com/read_requests' and limit 'ReadRequestsPerMinutePerUser' of s
ervice 'logging.googleapis.com' for consumer 'project_number:xxxxxxxx'.
    at new createStatusError (/Users/campionfellin/Desktop/gcp-work/clasp/node_modules/grpc/src/client.js:64:15)
    at /Users/campionfellin/Desktop/gcp-work/clasp/node_modules/grpc/src/client.js:583:15
  code: 8,
  metadata:
   Metadata {
     _internal_repr:
      { 'google.rpc.help-bin': [Array],
```

My guess is that this error comes about because StackDriver logging takes a few minutes to get all set up. This PR catches that error and tells the user to try again.

I also noticed another severity level of `NOTICE` and so added that as well.

Signed-off-by: campionfellin <campionfellin@gmail.com>

Closes https://github.com/google/clasp/issues/128

- [x] `npm run test` succeeds.
- [x] Appropriate changes to README are included in PR.
