### PR TITLE
Adds tests for clasp deploy and clasp deployments

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -116,7 +116,7 @@ const ERROR = {
 Forgot ${PROJECT_NAME} commands? Get help:\n  ${PROJECT_NAME} --help`,
   CONFLICTING_FILE_EXTENSION: (name: string) => `File names: ${name}.js/${name}.gs conflict. Only keep one.`,
   CREATE: 'Error creating script.',
-  DEPLOYMENT_COUNT: `Unable to deploy; Only one deployment can be created at a time`,
+  DEPLOYMENT_COUNT: `Unable to deploy; Scripts may only have up to 20 versioned deployments at a time.`,
   FOLDER_EXISTS: `Project file (${DOT.PROJECT.PATH}) already exists.`,
   FS_DIR_WRITE: 'Could not create directory.',
   FS_FILE_WRITE: 'Could not write file.',
@@ -821,12 +821,12 @@ commander
               manifestFileName: PROJECT_MANIFEST_BASENAME,
               description,
             },
-          }, {}, (err: any, { data }: any) => {
+          }, {}, (err: any, response: any) => {
             spinner.stop(true);
             if (err) {
               console.error(ERROR.DEPLOYMENT_COUNT);
-            } else {
-              console.log(`- ${data.deploymentId} @${versionNumber}.`);
+            } else if (response) {
+              console.log(`- ${response.data.deploymentId} @${versionNumber}.`);
             }
           });
         }

--- a/tests/test.ts
+++ b/tests/test.ts
@@ -122,6 +122,26 @@ describe.skip('Test clasp clone function', () => {
   });
 });
 
+describe.skip('Test clasp deployments function', () => {
+  it('should list deployments correctly', () => {
+    const result = spawnSync(
+      'clasp', ['deployments'], { encoding: 'utf8' },
+    );
+    expect(result.stdout).to.contain('Deployments.');
+    expect(result.status).to.equal(0);
+  });
+});
+
+describe.skip('Test clasp deploy function', () => {
+  it('should deploy correctly', () => {
+    const result = spawnSync(
+      'clasp', ['deploy'], { encoding: 'utf8' },
+    );
+    expect(result.stdout).to.contain('Created version ');
+    expect(result.status).to.equal(0);
+  });
+});
+
 // Fails when you logged in using --ownkey flag
 describe.skip('Test clasp logout function', () => {
   it('should logout correctly', () => {


### PR DESCRIPTION
Additionally, gives a better error message for when a deployment fails and fixes an unhandled promise error.

Signed-off-by: campionfellin <campionfellin@gmail.com>

- [x] `npm run test` succeeds.
- [ ] Appropriate changes to README are included in PR.
