### PR TITLE
Allow clasp open to work for any scriptId

### DIFF
--- a/README.md
+++ b/README.md
@@ -110,7 +110,7 @@ clasp deployments # List all deployment IDs
 clasp open [scriptId]
 ```
 
-Takes an optional argument of the scriptId that you'd like to open. Else, opens script from `.clasp.json`
+Opens the `clasp` project on script.google.com. Provide a `scriptId` to open a different script.
 
 ### List your App Scripts (In Development)
 

--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ clasp
 - `clasp clone <scriptId>`
 - `clasp pull`
 - `clasp push`
-- `clasp open`
+- `clasp open [scriptId]`
 - `clasp deployments`
 - `clasp deploy [version] [description]`
 - `clasp redeploy <deploymentId> <version> <description>`
@@ -107,8 +107,10 @@ clasp deployments # List all deployment IDs
 ### Open the Project on script.google.com
 
 ```
-clasp open
+clasp open [scriptId]
 ```
+
+Takes an optional argument of the scriptId that you'd like to open. Else, opens script from `.clasp.json`
 
 ### List your App Scripts (In Development)
 

--- a/index.ts
+++ b/index.ts
@@ -628,19 +628,26 @@ commander
  * Opens the script editor in the user's browser.
  */
 commander
-  .command('open')
+  .command('open [scriptId]')
   .description('Open a script')
-  .action((scriptId: string) => {
-    getProjectSettings().then(async ({ scriptId }: ProjectSettings) => {
-      if (scriptId) {
-        if (scriptId.length < 30) {
-          logError(null, ERROR.SCRIPT_ID_INCORRECT(scriptId));
-        } else {
-          console.log(LOG.OPEN_PROJECT(scriptId));
-          open(getScriptURL(scriptId));
-        }
+  .action(async (scriptId: string) => {
+    const openScript = (scriptId) => {
+      if (scriptId.length < 30) {
+        logError(null, ERROR.SCRIPT_ID_INCORRECT(scriptId));
+      } else {
+        console.log(LOG.OPEN_PROJECT(scriptId));
+        open(getScriptURL(scriptId));
       }
-    });
+    };
+    if (scriptId) {
+      openScript(scriptId);
+    } else {
+      getProjectSettings().then(async ({ scriptId }: ProjectSettings) => {
+        if (scriptId) {
+          openScript(scriptId);
+        }
+      });
+    }
   });
 
 /**

--- a/index.ts
+++ b/index.ts
@@ -631,7 +631,8 @@ commander
   .command('open [scriptId]')
   .description('Open a script')
   .action(async (scriptId: string) => {
-    const openScript = (scriptId) => {
+    const openScript = (scriptId?) => {
+      if (!scriptId) return;
       if (scriptId.length < 30) {
         logError(null, ERROR.SCRIPT_ID_INCORRECT(scriptId));
       } else {
@@ -642,11 +643,7 @@ commander
     if (scriptId) {
       openScript(scriptId);
     } else {
-      getProjectSettings().then(async ({ scriptId }: ProjectSettings) => {
-        if (scriptId) {
-          openScript(scriptId);
-        }
-      });
+      getProjectSettings().then(openScript);
     }
   });
 


### PR DESCRIPTION
Adds optional parameter [scriptId] to clasp open command.

Signed-off-by: campionfellin <campionfellin@gmail.com>

Fixes #100 

- [x] `npm run test` succeeds.
- [x] `npm run lint` succeeds.
- [x] Appropriate changes to README are included in PR.
