### PR TITLE
Move more items to utils and fix clasp open

### DIFF
--- a/src/utils.ts
+++ b/src/utils.ts
@@ -6,6 +6,7 @@ import * as fs from 'fs';
 const dotf = require('dotf');
 const read = require('read-file');
 import { Spinner } from 'cli-spinner';
+const isOnline = require('is-online');
 
 // Names / Paths
 export const PROJECT_NAME = 'clasp';
@@ -191,4 +192,40 @@ export function getProjectSettings(failSilently?: boolean): Promise<ProjectSetti
  */
 export function getFileType(type: string): string {
   return (type === 'SERVER_JS') ? 'js' : type.toLowerCase();
+}
+
+/**
+ * Gets the API FileType. Assumes the path is valid.
+ * @param  {string} path The file path
+ * @return {string}      The API's FileType enum (uppercase), null if not valid.
+ */
+export function getAPIFileType(path: string): string {
+  const extension: string = path.substr(path.lastIndexOf('.') + 1).toUpperCase();
+  return (extension === 'GS' || extension === 'JS') ? 'SERVER_JS' : extension.toUpperCase();
+}
+
+/**
+ * Checks if the network is available. Gracefully exits if not.
+ */
+export async function checkIfOnline() {
+  if (!(await isOnline())) {
+    logError(null, ERROR.OFFLINE);
+    process.exit(1);
+  }
+}
+
+/**
+ * Saves the script ID in the project dotfile.
+ * @param  {string} scriptId The script ID
+ */
+export function saveProjectId(scriptId: string): void {
+  DOTFILE.PROJECT().write({ scriptId }); // Save the script id
+}
+
+/**
+ * Checks if the current directory appears to be a valid project.
+ * @return {boolean} True if valid project, false otherwise
+ */
+export function manifestExists(): boolean {
+  return fs.existsSync(`${PROJECT_MANIFEST_BASENAME}.json`);
 }


### PR DESCRIPTION
Clasp open was trying to open an object, rather than the scriptID
Moved over manifestExists, saveProjectId, checkIfOnline, and getAPIFileType

Signed-off-by: campionfellin <campionfellin@gmail.com>

Works on #133 

- [x] `npm run test` succeeds.
- [x] `npm run lint` succeeds.
- [ ] Appropriate changes to README are included in PR.
