### PR TITLE
Fix build errors

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -24,6 +24,7 @@ import 'connect';
 import * as del from 'del';
 import * as fs from 'fs';
 import { google } from 'googleapis';
+import { Drive } from 'googleapis/build/src/apis/drive/v3';
 import * as mkdirp from 'mkdirp';
 const open = require('open');
 const path = require('path');
@@ -329,13 +330,13 @@ commander
   .action(async (scriptId: string, versionNumber?: number) => {
       if (!scriptId) {
         getAPICredentials(async () => {
-          const drive = google.drive({version: 'v3', auth: oauth2Client});
+          const drive = google.drive({version: 'v3', auth: oauth2Client}) as Drive;
           const { data } = await drive.files.list({
             pageSize: 10,
             fields: 'files(id, name)',
             q: "mimeType='application/vnd.google-apps.script'",
           });
-          const files = data['files'];
+          const files = data.files;
           const fileIds = [];
           if (files.length) {
             files.map((file: any) => {
@@ -705,14 +706,14 @@ commander
     await checkIfOnline();
     spinner.setSpinnerTitle(LOG.FINDING_SCRIPTS).start();
     getAPICredentials(async () => {
-      const drive = google.drive({version: 'v3', auth: oauth2Client});
+      const drive = google.drive({version: 'v3', auth: oauth2Client}) as Drive;
       const res = await drive.files.list({
         pageSize: 50,
         fields: 'nextPageToken, files(id, name)',
         q: "mimeType='application/vnd.google-apps.script'",
       });
       spinner.stop(true);
-      const files = res.data['files'];
+      const files = res.data.files;
       if (files.length) {
         files.map((file: any) => {
           console.log(`${file.name.padEnd(20)} – ${getScriptURL(file.id)}`);

--- a/index.ts
+++ b/index.ts
@@ -335,7 +335,7 @@ commander
             fields: 'files(id, name)',
             q: "mimeType='application/vnd.google-apps.script'",
           });
-          const files = data.files;
+          const files = data['files'];
           const fileIds = [];
           if (files.length) {
             files.map((file: any) => {
@@ -406,7 +406,7 @@ commander
             script.projects.updateContent({
               scriptId,
               resource: { files },
-            }, {}, (error: any, res: Function) => {
+            }, {}, (error: any) => {
               spinner.stop(true);
               if (error) {
                 console.error(LOG.PUSH_FAILURE);
@@ -712,7 +712,7 @@ commander
         q: "mimeType='application/vnd.google-apps.script'",
       });
       spinner.stop(true);
-      const files = res.data.files;
+      const files = res.data['files'];
       if (files.length) {
         files.map((file: any) => {
           console.log(`${file.name.padEnd(20)} – ${getScriptURL(file.id)}`);

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -6,6 +6,7 @@
       "es2015",
       "es5",
       "es6",
+      "es2017"
     ]
   },
   "moduleResolution": "node",


### PR DESCRIPTION
Now, there are less errors when running `sudo npm run build`.

The one that still persists is:

`Property 'redirectUri' is private and only accessible within class 'OAuth2Client'.`
 
Which will likely remain unless we change the way we make the `oauth2Client`.

Signed-off-by: campionfellin <campionfellin@gmail.com>

Fixes #<issue_number_goes_here> (it's a good idea to open an issue first for discussion)

- [x] `npm run test` succeeds.
- [x] `npm run lint` succeeds.
- [ ] Appropriate changes to README are included in PR.
