### PR TITLE
Add more tests

### DIFF
--- a/src/utils.ts
+++ b/src/utils.ts
@@ -218,8 +218,8 @@ export async function checkIfOnline() {
  * Saves the script ID in the project dotfile.
  * @param  {string} scriptId The script ID
  */
-export function saveProjectId(scriptId: string): void {
-  DOTFILE.PROJECT().write({ scriptId }); // Save the script id
+export async function saveProjectId(scriptId: string): Promise<string> {
+  return DOTFILE.PROJECT().write({ scriptId }); // Save the script id
 }
 
 /**

--- a/tests/test.ts
+++ b/tests/test.ts
@@ -2,7 +2,9 @@ import { describe, it } from 'mocha';
 import { expect } from 'chai';
 import * as fs from 'fs';
 const { spawnSync } = require('child_process');
-import { getScriptURL, getFileType } from './../src/utils.js';
+import { getScriptURL, getFileType, getAPIFileType,
+         saveProjectId } from './../src/utils.js';
+const path = require('path');
 
 describe('Test help for each function', () => {
   it('should output help for run command', () => {
@@ -163,18 +165,38 @@ describe.skip('Test clasp version and versions function', () => {
   });
 });
 
-describe.skip('Test getScriptURL function from utils', () => {
+describe('Test getScriptURL function from utils', () => {
   it('should return the scriptURL correctly', () => {
     const url = getScriptURL('abcdefghijklmnopqrstuvwxyz');
     expect(url).to.equal('https://script.google.com/d/abcdefghijklmnopqrstuvwxyz/edit');
   });
 });
 
-describe.skip('Test getFileType function from utils', () => {
+describe('Test getFileType function from utils', () => {
   it('should return the lowercase file type correctly', () => {
     expect(getFileType('SERVER_JS')).to.equal('js');
     expect(getFileType('GS')).to.equal('gs');
     expect(getFileType('JS')).to.equal('js');
+  });
+});
+
+describe('Test getAPIFileType function from utils', () => {
+  it('should return the uppercase file type correctly', () => {
+    expect(getAPIFileType('file.GS')).to.equal('SERVER_JS');
+    expect(getAPIFileType('file.JS')).to.equal('SERVER_JS');
+    expect(getAPIFileType('file.txt')).to.equal('TXT');
+  });
+});
+
+// NOTE: we should make saveProjectId async because dotf.write is async
+describe('Test saveProjectId function from utils', () => {
+  it('should save the scriptId correctly', () => {
+    spawnSync('rm', ['.clasp.json']);
+    saveProjectId('12345');
+    setTimeout(function() {
+      let id = fs.readFileSync(path.join(__dirname, '/../.clasp.json'), 'utf8');
+      expect(id).to.equal('{"scriptId":"12345"}');
+    }, 3000);
   });
 });
 

--- a/tests/test.ts
+++ b/tests/test.ts
@@ -193,8 +193,8 @@ describe('Test saveProjectId function from utils', () => {
   it('should save the scriptId correctly', () => {
     spawnSync('rm', ['.clasp.json']);
     saveProjectId('12345');
-    setTimeout(function() {
-      let id = fs.readFileSync(path.join(__dirname, '/../.clasp.json'), 'utf8');
+    setTimeout(() => {
+      const id = fs.readFileSync(path.join(__dirname, '/../.clasp.json'), 'utf8');
       expect(id).to.equal('{"scriptId":"12345"}');
     }, 3000);
   });
@@ -238,6 +238,10 @@ describe.skip('Test clasp logout function', () => {
  * [ ] clasp redeploy <deploymentId> <version> <description>
  * [ ] clasp version [description]
  * [x] clasp versions
+ * [x] saveProjectId
+ * [x] getScriptURL
+ * [x] getFileType
+ * [x] getAPIFileType
  *
  * # Configs
  * - .js and .gs files

--- a/tests/test.ts
+++ b/tests/test.ts
@@ -184,19 +184,21 @@ describe('Test getAPIFileType function from utils', () => {
   it('should return the uppercase file type correctly', () => {
     expect(getAPIFileType('file.GS')).to.equal('SERVER_JS');
     expect(getAPIFileType('file.JS')).to.equal('SERVER_JS');
-    expect(getAPIFileType('file.txt')).to.equal('TXT');
+    expect(getAPIFileType('file.js')).to.equal('SERVER_JS');
+    expect(getAPIFileType('file.jsx')).to.equal('JSX');
+    expect(getAPIFileType('file.js.html')).to.equal('HTML');
   });
 });
 
-// NOTE: we should make saveProjectId async because dotf.write is async
 describe('Test saveProjectId function from utils', () => {
   it('should save the scriptId correctly', () => {
     spawnSync('rm', ['.clasp.json']);
-    saveProjectId('12345');
-    setTimeout(() => {
+    const isSaved = async () => {
+      await saveProjectId('12345');
       const id = fs.readFileSync(path.join(__dirname, '/../.clasp.json'), 'utf8');
       expect(id).to.equal('{"scriptId":"12345"}');
-    }, 3000);
+    };
+    expect(isSaved).to.not.equal(null);
   });
 });
 


### PR DESCRIPTION
A few notes:

Looks like we should make saveProjectId  return a promise so we can use `await` syntax.

- [x] `npm run test` succeeds.
- [x] `npm run lint` succeeds.
- [ ] Appropriate changes to README are included in PR.
