### PR TITLE
Import pluralize to index.ts

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -34,6 +34,7 @@ import * as recursive from 'recursive-readdir';
 const logging = require('@google-cloud/logging');
 const chalk = require('chalk');
 const { prompt } = require('inquirer');
+import * as pluralize from 'pluralize';
 import { DOT, PROJECT_NAME, PROJECT_MANIFEST_BASENAME, ClaspSettings,
     ProjectSettings, DOTFILE, spinner, logError, ERROR, getScriptURL,
     getProjectSettings, getFileType, getAPIFileType, checkIfOnline,


### PR DESCRIPTION
This fixes `clasp deployments`. Somehow the lint missed that we don't import `pluralize` before running this:

https://github.com/google/clasp/blob/39e06906accc0a1dc2f624a9c44c72efce56b77c/index.ts#L506

Which gives an unhandled promise rejection.

This fixes that and should stabilize the build for npm.

Signed-off-by: campionfellin <campionfellin@gmail.com>

Fixes #<issue_number_goes_here> (it's a good idea to open an issue first for discussion)

- [x] `npm run test` succeeds.
- [x] `npm run lint` succeeds.
- [] Appropriate changes to README are included in PR.
