### PR TITLE
Fix clasp logout

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -219,6 +219,7 @@ commander
   .description('Log out')
   .action(() => {
     del(DOT.RC.ABSOLUTE_PATH, { force: true }); // del doesn't work with a relative path (~)
+    del(DOT.RC.ABSOLUTE_LOCAL_PATH, { force: true });
   });
 
 /**

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -30,6 +30,7 @@ export const DOT = {
       NAME: `${PROJECT_NAME}rc.json`,
       PATH: path.join('~', `.${PROJECT_NAME}rc.json`),
       ABSOLUTE_PATH: path.join(os.homedir(), `.${PROJECT_NAME}rc.json`),
+      ABSOLUTE_LOCAL_PATH: path.join('.', `.${PROJECT_NAME}rc.json`),
     },
 };
 

--- a/tests/test.ts
+++ b/tests/test.ts
@@ -1,6 +1,8 @@
 import { describe, it } from 'mocha';
 import { expect } from 'chai';
 import * as fs from 'fs';
+import * as os from 'os';
+
 const { spawnSync } = require('child_process');
 import { getScriptURL, getFileType, getAPIFileType,
          saveProjectId } from './../src/utils.js';
@@ -202,11 +204,10 @@ describe('Test saveProjectId function from utils', () => {
   });
 });
 
-// Fails when you logged in using --ownkey flag
 describe.skip('Test clasp logout function', () => {
   it('should logout correctly', () => {
     fs.writeFileSync('.clasprc.json', ' ');
-    fs.writeFileSync('~/.clasprc.json', ' ');
+    fs.writeFileSync(path.join(os.homedir(), '/.clasprc.json'), ' ');
     const result = spawnSync(
       'clasp', ['logout'], { encoding: 'utf8' },
     );


### PR DESCRIPTION
It now removes .clasprc.json file in the users current directory

Signed-off-by: campionfellin <campionfellin@gmail.com>

Fixes #124 

- [x] `npm run test` succeeds.
- [x] `npm run lint` succeeds.
- [ ] Appropriate changes to README are included in PR.
