### PR TITLE
Fix clasp login

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -206,8 +206,12 @@ commander
     DOTFILE.RC.read().then((rc: ClaspSettings) => {
       console.warn(ERROR.LOGGED_IN);
     }).catch(async (err: string) => {
-      await checkIfOnline();
-      authorize(options.localhost, options.ownkey);
+      DOTFILE.RC_LOCAL.read().then((rc: ClaspSettings) => {
+        console.warn(ERROR.LOGGED_IN);
+      }).catch(async (err: string) => {
+        await checkIfOnline();
+        authorize(options.localhost, options.ownkey);
+      });
     });
   });
 


### PR DESCRIPTION
Now it checks for local rc file before logging in.

Previously, if you ran `clasp login --ownkey` followed by `clasp login` you would have 2 `.clasprc.json` files, on in your homedir and one in your working directory. Now, it checks for a local rc file first.

Signed-off-by: campionfellin <campionfellin@gmail.com>

Works on #131 (note, that we may have to implement some sort of check before every command so they do not always default to the rc file in your homedir.)

- [ ] `npm run test` succeeds. (no tests for login yet)
- [x] `npm run lint` succeeds.
- [ ] Appropriate changes to README are included in PR.
