### PR TITLE
Fix getAPICredentials so it looks in local RC first then global RC

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -828,7 +828,7 @@ commander
           console.log(e);
         });
       });
-    }, true);
+    });
   });
 
 /**

--- a/src/auth.ts
+++ b/src/auth.ts
@@ -21,15 +21,19 @@ export const oauth2Client = new OAuth2Client({
  * @param {Function} cb The callback
  * @param {boolean} isLocal If we should load local API credentials for this clasp project.
  */
-export function getAPICredentials(cb: (rc: ClaspSettings | void) => void, isLocal?: boolean) {
-    const dotfile = isLocal ? DOTFILE.RC_LOCAL : DOTFILE.RC;
-    dotfile.read().then((rc: ClaspSettings) => {
+export function getAPICredentials(cb: (rc: ClaspSettings | void) => void) {
+    DOTFILE.RC_LOCAL.read().then((rc: ClaspSettings) => {
       oauth2Client.setCredentials(rc);
       cb(rc);
     }).catch((err: object) => {
-      console.error('Could not read API credentials. Error:');
-      console.error(err);
-      process.exit(-1);
+      DOTFILE.RC.read().then((rc: ClaspSettings) => {
+        oauth2Client.setCredentials(rc);
+        cb(rc);
+      }).catch((err: object) => {
+        console.error('Could not read API credentials. Error:');
+        console.error(err);
+        process.exit(-1);
+      });
     });
   }
 


### PR DESCRIPTION
Now, rather than passing a boolean to getAPICredentials of whether you're using local RC, it'll just check there first before moving up to the home dir.

`clasp run` was the only place it actually passed `true`, the rest of the commands use nothing (`false`) and thus is why they didn't pick up on a local RC file.

This will also probably help with testing as well, using Travis with encrypted creds.

Signed-off-by: campionfellin <campionfellin@gmail.com>

Closes #131 

- [x] `npm run test` succeeds. (both using `clasp login` and `clasp login --ownkey`
- [x] `npm run lint` succeeds.
- [ ] Appropriate changes to README are included in PR.
