### PR TITLE
Edit clasp clone to include project names

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -346,7 +346,7 @@ commander
           const fileIds = [];
           if (files.length) {
             files.map((file: any) => {
-              fileIds.push(`${file.id} - (${file.name})`);
+              fileIds.push(`${file.name}`.padEnd(20) + ` - (${file.id})`);
             });
             await prompt([{
               type : 'list',

--- a/index.ts
+++ b/index.ts
@@ -346,7 +346,7 @@ commander
           const fileIds = [];
           if (files.length) {
             files.map((file: any) => {
-              fileIds.push(file.id);
+              fileIds.push(`${file.id} - (${file.name})`);
             });
             await prompt([{
               type : 'list',


### PR DESCRIPTION
Now `clasp clone` shows `projectId - (projectName)` so users can more easily pick the project they want to clone.

Would we rather have it as `projectId - projectName` or `projectName - projectId`?

Signed-off-by: campionfellin <campionfellin@gmail.com>

- [x] `npm run test` succeeds.
- [x] `npm run lint` succeeds.
- [ ] Appropriate changes to README are included in PR.
