### PR TITLE
Return -1 when push failed

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -424,6 +424,7 @@ commander
                 nonIgnoredFilePaths.map((filePath: string) => {
                   console.error(`└─ ${filePath}`);
                 });
+                process.exit(-1);
               } else {
                 nonIgnoredFilePaths.map((filePath: string) => {
                   console.log(`└─ ${filePath}`);

--- a/tests/test.ts
+++ b/tests/test.ts
@@ -105,6 +105,16 @@ describe.skip('Test clasp push function', () => {
     expect(result.stdout).to.contain('files.');
     expect(result.status).to.equal(0);
   });
+  it('should return non-0 exit code when push failed', () => {
+    fs.writeFileSync('.claspignore', '**/**\n!Code.js\n!appsscript.json');
+    fs.writeFileSync('unexpected_file', '');
+    const result = spawnSync(
+      'clasp', ['push'], { encoding: 'utf8' },
+    );
+    expect(result.stdout).to.contain('failed.');
+    expect(result.stdout).to.contain('files.');
+    expect(result.status).to.equal(-1);
+  });
 });
 
 describe.skip('Test clasp status function', () => {


### PR DESCRIPTION
Fixes #174

- [x] `npm run test` succeeds.
- [x] `npm run lint` succeeds.
- [ ] Appropriate changes to README are included in PR.
