### PR TITLE
Update tsconfig to include strict as a compiler option

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -7,7 +7,8 @@
       "es5",
       "es6",
       "es2017"
-    ]
+    ],
+    "strict": true,
   },
   "moduleResolution": "node",
   "files": [


### PR DESCRIPTION
This will enable strict compiling by default, so that we can see errors like those brought up in #181 .

Signed-off-by: campionfellin <campionfellin@gmail.com>

Related to #181 

- [x] `npm run test` succeeds.
- [x] `npm run lint` succeeds.
- [ ] Appropriate changes to README are included in PR.
