### PR TITLE
Move login function to commands.ts file

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -164,12 +164,7 @@ commander
   .description('Log in to script.google.com')
   .option('--no-localhost', 'Do not run a local server, manually enter code instead')
   .option('--ownkey', 'Save .clasprc.json file to current working directory')
-  .action((options: {
-    localhost: boolean;
-    ownkey: boolean;
-  }) => {
-    login(options);
-  });
+  .action(login);
 
 /**
  * Logs out the user by deleteing client credentials.

--- a/index.ts
+++ b/index.ts
@@ -35,12 +35,12 @@ const logging = require('@google-cloud/logging');
 const chalk = require('chalk');
 const { prompt } = require('inquirer');
 import * as pluralize from 'pluralize';
-import { DOT, PROJECT_NAME, PROJECT_MANIFEST_BASENAME, ClaspSettings,
+import { DOT, PROJECT_NAME, PROJECT_MANIFEST_BASENAME,
     ProjectSettings, DOTFILE, spinner, logError, ERROR, getScriptURL,
     getProjectSettings, getFileType, getAPIFileType, checkIfOnline,
     saveProjectId, manifestExists } from './src/utils.js';
-import { oauth2Client, getAPICredentials, authorize } from './src/auth';
-import { LOG } from './src/commands.js';
+import { oauth2Client, getAPICredentials } from './src/auth';
+import { LOG, login } from './src/commands.js';
 // An Apps Script API File
 interface AppsScriptFile {
   name: string;
@@ -168,17 +168,7 @@ commander
     localhost: boolean;
     ownkey: boolean;
   }) => {
-    // Try to read the RC file.
-    DOTFILE.RC.read().then((rc: ClaspSettings) => {
-      console.warn(ERROR.LOGGED_IN);
-    }).catch(async (err: string) => {
-      DOTFILE.RC_LOCAL.read().then((rc: ClaspSettings) => {
-        console.warn(ERROR.LOGGED_IN);
-      }).catch(async (err: string) => {
-        await checkIfOnline();
-        authorize(options.localhost, options.ownkey);
-      });
-    });
+    login(options);
   });
 
 /**

--- a/src/auth.ts
+++ b/src/auth.ts
@@ -115,6 +115,7 @@ export async function authorize(useLocalhost: boolean, writeToOwnKey: boolean) {
     const token = await (useLocalhost ? authorizeWithLocalhost() : authorizeWithoutLocalhost());
     await (writeToOwnKey ? DOTFILE.RC_LOCAL.write(token) : DOTFILE.RC.write(token));
     console.log(LOG.AUTH_SUCCESSFUL);
+    process.exit(0);
   } catch(err) {
     console.error(ERROR.ACCESS_TOKEN + err);
   }

--- a/src/auth.ts
+++ b/src/auth.ts
@@ -115,7 +115,7 @@ export async function authorize(useLocalhost: boolean, writeToOwnKey: boolean) {
     const token = await (useLocalhost ? authorizeWithLocalhost() : authorizeWithoutLocalhost());
     await (writeToOwnKey ? DOTFILE.RC_LOCAL.write(token) : DOTFILE.RC.write(token));
     console.log(LOG.AUTH_SUCCESSFUL);
-    process.exit(0);
+    process.exit(0); // gracefully exit after successful login
   } catch(err) {
     console.error(ERROR.ACCESS_TOKEN + err);
   }

--- a/src/auth.ts
+++ b/src/auth.ts
@@ -115,7 +115,7 @@ export async function authorize(useLocalhost: boolean, writeToOwnKey: boolean) {
     const token = await (useLocalhost ? authorizeWithLocalhost() : authorizeWithoutLocalhost());
     await (writeToOwnKey ? DOTFILE.RC_LOCAL.write(token) : DOTFILE.RC.write(token));
     console.log(LOG.AUTH_SUCCESSFUL);
-    process.exit(0); // gracefully exit after successful login
+    process.exit(0);
   } catch(err) {
     console.error(ERROR.ACCESS_TOKEN + err);
   }

--- a/src/commands.ts
+++ b/src/commands.ts
@@ -1,4 +1,6 @@
-import { DOT, PROJECT_NAME, getScriptURL } from './utils.js';
+import { DOT, PROJECT_NAME, getScriptURL, ClaspSettings, DOTFILE, ERROR,
+checkIfOnline } from './utils.js';
+import { authorize } from './auth.js';
 import * as pluralize from 'pluralize';
 
 // Log messages (some logs take required params)
@@ -37,3 +39,16 @@ export const LOG = {
         (description || '(no description)'),
     VERSION_NUM: (numVersions: number) => `~ ${numVersions} ${pluralize('Version', numVersions)} ~`,
   };
+
+export function login(options) {
+    DOTFILE.RC.read().then((rc: ClaspSettings) => {
+        console.warn(ERROR.LOGGED_IN);
+      }).catch(async (err: string) => {
+        DOTFILE.RC_LOCAL.read().then((rc: ClaspSettings) => {
+          console.warn(ERROR.LOGGED_IN);
+        }).catch(async (err: string) => {
+          await checkIfOnline();
+          authorize(options.localhost, options.ownkey);
+        });
+      });
+}

--- a/src/commands.ts
+++ b/src/commands.ts
@@ -40,15 +40,19 @@ export const LOG = {
     VERSION_NUM: (numVersions: number) => `~ ${numVersions} ${pluralize('Version', numVersions)} ~`,
   };
 
-export function login(options) {
-    DOTFILE.RC.read().then((rc: ClaspSettings) => {
+/**
+ * Logs the user in. Saves the client credentials to an rc file.
+ * @param options the localhost and ownkey options from commander
+ */
+export function login(options: { localhost: boolean, ownkey: boolean}) {
+  DOTFILE.RC.read().then((rc: ClaspSettings) => {
+      console.warn(ERROR.LOGGED_IN);
+    }).catch(async (err: string) => {
+      DOTFILE.RC_LOCAL.read().then((rc: ClaspSettings) => {
         console.warn(ERROR.LOGGED_IN);
       }).catch(async (err: string) => {
-        DOTFILE.RC_LOCAL.read().then((rc: ClaspSettings) => {
-          console.warn(ERROR.LOGGED_IN);
-        }).catch(async (err: string) => {
-          await checkIfOnline();
-          authorize(options.localhost, options.ownkey);
-        });
+        await checkIfOnline();
+        authorize(options.localhost, options.ownkey);
       });
+    });
 }


### PR DESCRIPTION
This PR does a couple of things:

* Moves `login` functionality to `commands.ts` file. 
* Also adds `process.exit(0)` after `clasp login` so that it will end after logging in (otherwise after you login you need `CTRL+C` after logging in).

Signed-off-by: campionfellin <campionfellin@gmail.com>

Works towards a model for #134 

- [x] `npm run test` succeeds.
- [x] `npm run lint` succeeds.
- [ ] Appropriate changes to README are included in PR.
