### PR TITLE
Remove duplicate test and fix clasp push test

### DIFF
--- a/tests/test.ts
+++ b/tests/test.ts
@@ -50,17 +50,6 @@ describe.skip('Test clasp create function', () => {
   });
 });
 
-describe.skip('Test clasp create <projectName> function', () => {
-  it('should create a new project correctly', () => {
-    spawnSync('rm', ['.clasp.json']);
-    const result = spawnSync(
-      'clasp', ['create', 'sampleProject'], { encoding: 'utf8' },
-    );
-    expect(result.stdout).to.contain('Created new script: https://script.google.com/d/');
-    expect(result.status).to.equal(0);
-  });
-});
-
 describe.skip('Test clasp create <title> function', () => {
   it('should create a new project named <title> correctly', () => {
     spawnSync('rm', ['.clasp.json']);
@@ -106,7 +95,7 @@ describe.skip('Test clasp push function', () => {
     expect(result.status).to.equal(0);
   });
   it('should return non-0 exit code when push failed', () => {
-    fs.writeFileSync('.claspignore', '**/**\n!Code.js\n!appsscript.json');
+    fs.writeFileSync('.claspignore', '**/**\n!Code.js\n!appsscript.json\n!unexpected_file');
     fs.writeFileSync('unexpected_file', '');
     const result = spawnSync(
       'clasp', ['push'], { encoding: 'utf8' },


### PR DESCRIPTION
Remove duplicate of `clasp create <projectName>` test.

Also, add `!unexpected_file` to the `.claspignore` file for the `clasp push` test. Otherwise, it won't fail because it ignores that file anyway. The failure message should look something like:

```
👽  clasp push                                                    temp : master*
Push failed. Errors:
Invalid value at 'files[2].type' (TYPE_ENUM), "UNEXPECTED_FILE"
Files to push were:
└─ Code.js
└─ appsscript.json
└─ unexpected_file
```

with this as the `.claspignore`

```
👽  cat .claspignore                                              temp : master*
**/**
!Code.js
!appsscript.json
!unexpected_file
```


Signed-off-by: campionfellin <campionfellin@gmail.com>

Fixes #175 

- [x] `npm run test` succeeds.
- [x] `npm run lint` succeeds.
- [x] Appropriate changes to README are included in PR.
