### PR TITLE
Fix order of checking if .clasp.json exists

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -192,22 +192,22 @@ commander
   .command('create [scriptTitle] [scriptParentId]')
   .description('Create a script')
   .action(async (title: string, parentId: string) => {
-    if (!title) {
-      await prompt([{
-        type : 'input',
-        name : 'title',
-        message : 'Give a script title:',
-        default: LOG.UNTITLED_SCRIPT_TITLE,
-      }]).then((answers: any) => {
-        title = answers.title;
-      }).catch((err: any) => {
-        console.log(err);
-      });
-    }
     await checkIfOnline();
     if (fs.existsSync(DOT.PROJECT.PATH)) {
       logError(null, ERROR.FOLDER_EXISTS);
     } else {
+      if (!title) {
+        await prompt([{
+          type : 'input',
+          name : 'title',
+          message : 'Give a script title:',
+          default: LOG.UNTITLED_SCRIPT_TITLE,
+        }]).then((answers: any) => {
+          title = answers.title;
+        }).catch((err: any) => {
+          console.log(err);
+        });
+      }
       getAPICredentials(async () => {
         spinner.setSpinnerTitle(LOG.CREATE_PROJECT_START(title)).start();
         try {

--- a/tests/test.ts
+++ b/tests/test.ts
@@ -45,8 +45,15 @@ describe.skip('Test clasp create function', () => {
     const result = spawnSync(
       'clasp', ['create'], { encoding: 'utf8' },
     );
-    expect(result.stdout).to.contain('give a script title:');
+    expect(result.stdout).to.contain('Give a script title:');
     expect(result.status).to.equal(0);
+  });
+  it('should not prompt for project name', () => {
+    fs.writeFileSync('.clasp.json', '');
+    const result = spawnSync(
+      'clasp', ['create'], { encoding: 'utf8' },
+    );
+    expect(result.stderr).to.contain('Project file (.clasp.json) already exists.');
   });
 });
 


### PR DESCRIPTION
Will write tests for this either in this PR, or in another, whichever you think is best.

Signed-off-by: campionfellin <campionfellin@gmail.com>

Fixes #188 

- [x] `npm run test` succeeds.
- [x] `npm run lint` succeeds.
- [ ] Appropriate changes to README are included in PR.
