### PR TITLE
Fix clasp clone with no scriptId given

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -306,6 +306,8 @@ commander
               message : 'Clone which script? ',
               choices : fileIds,
             }]).then((answers: any) => {
+              answers.scriptId = answers.scriptId.substring(answers.scriptId.lastIndexOf('(') + 1,
+                                 answers.scriptId.length - 1);
               checkIfOnline();
               spinner.setSpinnerTitle(LOG.CLONING);
               saveProjectId(answers.scriptId);


### PR DESCRIPTION
Not sure that I like the hack-y way of getting the scriptId, but assuming that the scriptId itself shouldn't contain any `(` then I think it is valid, using `lastIndexOf("(")` for the start of the scriptId.

Signed-off-by: campionfellin <campionfellin@gmail.com>

Fixes #187 

- [x] `npm run test` succeeds.
- [x] `npm run lint` succeeds.
- [ ] Appropriate changes to README are included in PR.
