### PR TITLE
Clasp clone now exits with error if .clasp.json already exists

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -291,6 +291,10 @@ commander
   .command('clone [scriptId] [versionNumber]')
   .description('Clone a project')
   .action(async (scriptId: string, versionNumber?: number) => {
+    await checkIfOnline();
+    if (fs.existsSync(DOT.PROJECT.PATH)) {
+      logError(null, ERROR.FOLDER_EXISTS);
+    } else {
       if (!scriptId) {
         getAPICredentials(async () => {
           const drive = google.drive({version: 'v3', auth: oauth2Client}) as Drive;
@@ -325,11 +329,11 @@ commander
           }
         });
       } else {
-        await checkIfOnline();
         spinner.setSpinnerTitle(LOG.CLONING);
         saveProjectId(scriptId);
         fetchProject(scriptId, '', versionNumber);
       }
+    }
   });
 
 /**

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -134,6 +134,7 @@ export const logError = (err: any, description = '') => {
     }
     if (description) console.error(description);
   }
+  process.exit(1);
 };
 
 /**

--- a/tests/test.ts
+++ b/tests/test.ts
@@ -71,6 +71,7 @@ describe.skip('Test clasp create <title> function', () => {
 describe.skip('Test clasp clone <scriptId> function', () => {
   it('should clone an existing project correctly', () => {
     const settings = JSON.parse(fs.readFileSync('.clasp.json', 'utf8'));
+    fs.removeSync('.clasp.json');
     const result = spawnSync(
       'clasp', ['clone', settings.scriptId], { encoding: 'utf8' },
     );
@@ -172,6 +173,14 @@ describe.skip('Test clasp clone function', () => {
     );
     expect(result.stdout).to.contain('Clone which script?');
     expect(result.status).to.equal(0);
+  });
+  it('should give an error if .clasp.json already exists', () => {
+    fs.writeFileSync('.clasp.json', '');
+    const result = spawnSync(
+      'clasp', ['clone'], { encoding: 'utf8' },
+    );
+    expect(result.stderr).to.contain('Project file (.clasp.json) already exists.');
+    expect(result.status).to.equal(1);
   });
 });
 


### PR DESCRIPTION
As per discussion here: https://github.com/google/clasp/pull/194

`clasp clone` now errors if a `.clasp.json` file already exists. I have also created a test for this. Additionally, the function `logError` now exits with status 1.

Signed-off-by: campionfellin <campionfellin@gmail.com>

- [x] `npm run test` succeeds.
- [x] `npm run lint` succeeds.
- [ ] Appropriate changes to README are included in PR.
