### PR TITLE
LOG needs pluralize library

### DIFF
--- a/src/utils.ts
+++ b/src/utils.ts
@@ -7,6 +7,7 @@ const splitLines = require('split-lines');
 const dotf = require('dotf');
 const read = require('read-file');
 const isOnline = require('is-online');
+import * as pluralize from 'pluralize';
 
 // Names / Paths
 export const PROJECT_NAME = 'clasp';


### PR DESCRIPTION
Noticed this when running tests,

`clasp clone` gets unhandled promise rejection. This is due to it calling `fetchProject(scriptId, '', versionNumber);` which then uses `console.log(LOG.CLONE_SUCCESS(data.files.length));`. The `LOG.CLONE_SUCCESS` function needs `pluralize, but it wasn't imported earlier.

Signed-off-by: campionfellin <campionfellin@gmail.com>

Fixes #<issue_number_goes_here> (it's a good idea to open an issue first for discussion)

- [ ] `npm run test` succeeds.
- [x] `npm run lint` succeeds.
- [ ] Appropriate changes to README are included in PR.
