### PR TITLE
Load credentials is now async

### DIFF
--- a/src/auth.ts
+++ b/src/auth.ts
@@ -66,21 +66,19 @@ async function authorize(useLocalhost: boolean, writeToOwnKey: boolean) {
 /**
  * Loads the Apps Script API credentials for the CLI.
  * Required before every API call.
- * @param {Function} cb The callback
- * @param {boolean} isLocal If we should load local API credentials for this clasp project.
  */
-export function getAPICredentials(cb: (rc: ClaspSettings | void) => void) {
-    DOTFILE.RC_LOCAL.read().then((rc: ClaspSettings) => {
+export async function getAPICredentials() {
+    return DOTFILE.RC_LOCAL.read().then((rc: ClaspSettings) => {
       oauth2Client.setCredentials(rc);
-      cb(rc);
+      return rc;
     }).catch((err: any) => {
-      DOTFILE.RC.read().then((rc: ClaspSettings) => {
+      return DOTFILE.RC.read().then((rc: ClaspSettings) => {
         oauth2Client.setCredentials(rc);
-        cb(rc);
+        return rc;
       }).catch((err: any) => {
         console.error('Could not read API credentials. Error:');
         console.error(err);
-        process.exit(-1);
+        process.exit(1);
       });
     });
   }

--- a/src/auth.ts
+++ b/src/auth.ts
@@ -68,17 +68,20 @@ async function authorize(useLocalhost: boolean, writeToOwnKey: boolean) {
  * Required before every API call.
  */
 export async function loadAPICredentials() {
-    return DOTFILE.RC_LOCAL.read().then((rc: ClaspSettings) => {
-      oauth2Client.setCredentials(rc);
-      return rc;
-    }).catch((err: any) => {
-      return DOTFILE.RC.read().then((rc: ClaspSettings) => {
+    return new Promise((resolve, reject) => {
+      DOTFILE.RC_LOCAL.read().then((rc: ClaspSettings) => {
         oauth2Client.setCredentials(rc);
-        return rc;
+        resolve();
       }).catch((err: any) => {
-        console.error('Could not read API credentials. Error:');
-        console.error(err);
-        process.exit(1);
+        DOTFILE.RC.read().then((rc: ClaspSettings) => {
+          oauth2Client.setCredentials(rc);
+          resolve();
+        }).catch((err: any) => {
+          console.error('Could not read API credentials. Error:');
+          console.error(err);
+          reject();
+          process.exit(1);
+        });
       });
     });
   }

--- a/src/auth.ts
+++ b/src/auth.ts
@@ -68,22 +68,17 @@ async function authorize(useLocalhost: boolean, writeToOwnKey: boolean) {
  * Required before every API call.
  */
 export async function loadAPICredentials() {
-    return new Promise((resolve, reject) => {
-      DOTFILE.RC_LOCAL.read().then((rc: ClaspSettings) => {
-        oauth2Client.setCredentials(rc);
-        resolve();
-      }).catch((err: any) => {
-        DOTFILE.RC.read().then((rc: ClaspSettings) => {
-          oauth2Client.setCredentials(rc);
-          resolve();
-        }).catch((err: any) => {
-          console.error('Could not read API credentials. Error:');
-          console.error(err);
-          reject();
-          process.exit(1);
-        });
-      });
+  return DOTFILE.RC_LOCAL.read().then((rc: ClaspSettings) => {
+    oauth2Client.setCredentials(rc);
+  }).catch((err: any) => {
+    return DOTFILE.RC.read().then((rc: ClaspSettings) => {
+      oauth2Client.setCredentials(rc);
+    }).catch((err: any) => {
+      console.error('Could not read API credentials. Error:');
+      console.error(err);
+      process.exit(1);
     });
+  });
   }
 
 /**

--- a/src/auth.ts
+++ b/src/auth.ts
@@ -67,7 +67,7 @@ async function authorize(useLocalhost: boolean, writeToOwnKey: boolean) {
  * Loads the Apps Script API credentials for the CLI.
  * Required before every API call.
  */
-export async function getAPICredentials() {
+export async function loadAPICredentials() {
     return DOTFILE.RC_LOCAL.read().then((rc: ClaspSettings) => {
       oauth2Client.setCredentials(rc);
       return rc;

--- a/src/files.ts
+++ b/src/files.ts
@@ -2,7 +2,7 @@ import * as fs from 'fs';
 import * as anymatch from 'anymatch';
 import * as mkdirp from 'mkdirp';
 import * as recursive from 'recursive-readdir';
-import { getAPICredentials, script } from './auth';
+import { loadAPICredentials, script } from './auth';
 import { DOT, DOTFILE, ERROR, LOG, checkIfOnline, getAPIFileType, logError, spinner } from './utils';
 const path = require('path');
 const readMultipleFiles = require('read-multiple-files');
@@ -135,9 +135,9 @@ export function getProjectFiles(rootDir: string, callback: FilesCallback): void 
  * @param {number?} versionNumber The version of files to fetch.
  */
 export async function fetchProject(scriptId: string, rootDir = '', versionNumber?: number) {
-  spinner.start();
-  await getAPICredentials();
   await checkIfOnline();
+  await loadAPICredentials();
+  spinner.start();
   script.projects.getContent({
     scriptId,
     versionNumber,


### PR DESCRIPTION
Though it looks like a lot of changes, note that most of it is un-indenting the callbacks that were originally given to `getAPICredentials()`. It is now an `async` function, and any command that uses it has been changed to use `await getAPICredentials()` instead. 

Signed-off-by: campionfellin <campionfellin@gmail.com>

Fixes #201 
- [x] `npm run test` succeeds.
Results:
```
  19 passing (55s)
  4 pending

--------------|----------|----------|----------|----------|-------------------|
File          |  % Stmts | % Branch |  % Funcs |  % Lines | Uncovered Line #s |
--------------|----------|----------|----------|----------|-------------------|
All files     |    56.37 |    43.12 |    60.95 |    62.89 |                   |
 clasp        |    96.55 |       50 |      100 |    96.55 |                   |
  index.js    |    96.55 |       50 |      100 |    96.55 |               187 |
 clasp/src    |     53.9 |    47.11 |    59.53 |    59.03 |                   |
  auth.js     |    28.07 |    31.91 |    27.27 |    31.82 |... 39,240,241,245 |
  commands.js |    56.74 |    49.11 |    60.22 |    59.08 |... 05,706,707,733 |
  files.js    |    67.11 |    55.14 |     93.1 |    78.57 |... 82,192,194,197 |
  utils.js    |    60.61 |    48.21 |    67.35 |    70.16 |... 43,268,269,294 |
 clasp/tests  |    61.25 |     9.38 |     66.1 |    72.64 |                   |
  test.js     |    61.25 |     9.38 |     66.1 |    72.64 |... 55,256,257,258 |
--------------|----------|----------|----------|----------|-------------------|
```
- [x] `npm run lint` succeeds.
- [ ] Appropriate changes to README are included in PR.
