### PR TITLE
Fix Issue #211 by unwrapping data after checking for an error.

### DIFF
--- a/src/files.ts
+++ b/src/files.ts
@@ -141,12 +141,13 @@ export async function fetchProject(scriptId: string, rootDir = '', versionNumber
   script.projects.getContent({
     scriptId,
     versionNumber,
-  }, {}, (error: any, { data }: any) => {
+  }, {}, (error: any, res: any) => {
     spinner.stop(true);
     if (error) {
       if (error.statusCode === 404) return logError(null, ERROR.SCRIPT_ID_INCORRECT(scriptId));
       return logError(error, ERROR.SCRIPT_ID);
     } else {
+      const data = res.data;
       if (!data.files) {
         return logError(null, ERROR.SCRIPT_ID_INCORRECT(scriptId));
       }

--- a/tests/test.ts
+++ b/tests/test.ts
@@ -80,6 +80,13 @@ describe.skip('Test clasp clone <scriptId> function', () => {
     expect(result.stdout).to.contain('files.');
     expect(result.status).to.equal(0);
   });
+  it('should give an error on a non-existing project', () => {
+    const result = spawnSync(
+      'clasp', ['clone', 'non-existing-project'], { encoding: 'utf8' },
+    );
+    expect(result.stderr).to.contain('> Did you provide the correct scriptId?');
+    expect(result.status).to.equal(1);
+  });
 });
 
 describe.skip('Test clasp pull function', () => {


### PR DESCRIPTION
This should fix the unhandled promise rejection. Added an additional test so we can catch this in the future.

Signed-off-by: campionfellin <campionfellin@gmail.com>

Fixes #211 

- [x] `npm run test` succeeds.
- [x] `npm run lint` succeeds.
- [ ] Appropriate changes to README are included in PR.
