### PR TITLE
Make clasp logs timestamp descending and fix unhandled promise

### DIFF
--- a/src/commands.ts
+++ b/src/commands.ts
@@ -210,7 +210,7 @@ export const logs = async (cmd: {
 }) => {
   await checkIfOnline();
   function printLogs(entries: any[]) {
-    for (let i = 0; i < 50 && i < entries.length; ++i) {
+    for (let i = 0; i < 50 && entries ? i < entries.length : i < 0; ++i) {
       const { severity, timestamp, resource, textPayload, protoPayload, jsonPayload } = entries[i];
       let functionName = resource.labels.function_name;
       functionName = functionName ? functionName.padEnd(15) : ERROR.NO_FUNCTION_NAME;
@@ -253,6 +253,7 @@ export const logs = async (cmd: {
     resourceNames: [
       `projects/${projectId}`,
     ],
+    orderBy: 'timestamp desc',
   });
   printLogs(data.entries);
 };


### PR DESCRIPTION
Changes ordering of logs and also fixes error that looks like this:

```
(node:20742) UnhandledPromiseRejectionWarning: Unhandled promise rejection (rejection id: 1): TypeError: Cannot read property 'length' of undefined
(node:20742) [DEP0018] DeprecationWarning: Unhandled promise rejections are deprecated. In the future, promise rejections that are not handled will terminate the Node.js process with a non-zero exit code.
```
when entries is undefined.

Signed-off-by: campionfellin <campionfellin@gmail.com>

Relates to #216 

- [x] `npm run test` succeeds.
- [x] `npm run lint` succeeds.
- [ ] Appropriate changes to README are included in PR.
