### PR TITLE
Clarify setup logs

### DIFF
--- a/src/commands.ts
+++ b/src/commands.ts
@@ -224,6 +224,10 @@ export const logs = async (cmd: {
           protoPayload,
         };
         payloadData = data.textPayload || data.jsonPayload || data.protoPayload || ERROR.PAYLOAD_UNKNOWN;
+        if (payloadData && payloadData['@type'] === 'type.googleapis.com/google.cloud.audit.AuditLog') {
+          payloadData = LOG.STACKDRIVER_SETUP;
+          functionName = protoPayload.methodName.padEnd(15);
+        }
         if (payloadData && typeof(payloadData) === 'string') {
           payloadData = payloadData.padEnd(20);
         }

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -136,7 +136,7 @@ export const LOG = {
   PUSHING: 'Pushing files...',
   REDEPLOY_END: 'Updated deployment.',
   REDEPLOY_START: 'Updating deployment...',
-  STACKDRIVER_SETUP: 'Setting up Logging',
+  STACKDRIVER_SETUP: 'Setting up StackDriver Logging.',
   UNDEPLOYMENT_FINISH: (deploymentId: string) => `Undeployed ${deploymentId}.`,
   UNDEPLOYMENT_START: (deploymentId: string) => `Undeploy ${deploymentId}...`,
   UNTITLED_SCRIPT_TITLE: 'Untitled Script',

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -136,6 +136,7 @@ export const LOG = {
   PUSHING: 'Pushing files...',
   REDEPLOY_END: 'Updated deployment.',
   REDEPLOY_START: 'Updating deployment...',
+  STACKDRIVER_SETUP: 'Setting up Logging',
   UNDEPLOYMENT_FINISH: (deploymentId: string) => `Undeployed ${deploymentId}.`,
   UNDEPLOYMENT_START: (deploymentId: string) => `Undeploy ${deploymentId}...`,
   UNTITLED_SCRIPT_TITLE: 'Untitled Script',


### PR DESCRIPTION
Now, what previously looked like: 

```
🍔  clasp logs                                                                                                                    temp : master*
NOTICE     2018-06-16T22:58:26.975Z N/A [object Object]
NOTICE     2018-06-16T22:58:26.609Z N/A [object Object]
NOTICE     2018-06-16T22:58:23.896Z N/A [object Object]
```

now looks like:

```
🍔  clasp logs                                                                                                                                          temp : master*
NOTICE     2018-06-16T22:58:26.975Z CreateClient    Setting up Logging
NOTICE     2018-06-16T22:58:26.609Z CreateBrand     Setting up Logging
NOTICE     2018-06-16T22:58:23.896Z CreateProject   Setting up Logging
```

Signed-off-by: campionfellin <campionfellin@gmail.com>

Fixes #216 

- [x] `npm run test` succeeds.
- [x] `npm run lint` succeeds.
- [ ] Appropriate changes to README are included in PR.
