### PR TITLE
Adds `clasp push --watch`

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,5 +1,4 @@
 {
-    // The following will hide the js and map files in the editor
     "files.exclude": {
         "**/*.js": true,
     }

--- a/index.ts
+++ b/index.ts
@@ -127,10 +127,12 @@ commander
  * - That don't have an accepted file extension
  * - That are ignored (filename matches a glob pattern in the ignore file)
  * @example push
+ * @example push --watch
  */
 commander
   .command('push')
   .description('Update the remote project')
+  .option('--watch', 'Watches for local file changes. Pushes when a non-ignored file changs.')
   .action(push);
 
 /**

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@google/clasp",
-  "version": "1.3.1",
+  "version": "1.4.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -27,7 +27,7 @@
       "integrity": "sha512-M7+zuU/wPkgG74TZnS4lE/FD6pH4HQg/H7QHPInGfPcx+kfc9dam+yWbye6CAqdpUczdMjvN7NfBf1OUEJnAZA==",
       "dev": true,
       "requires": {
-        "@types/node": "9.6.18"
+        "@types/node": "9.6.22"
       }
     },
     "@types/commander": {
@@ -53,7 +53,7 @@
       "integrity": "sha512-4r8qa0quOvh7lGD0pre62CAb1oni1OO6ecJLGCezTmhQ8Fz50Arx9RUszryR8KlgK6avuSXvviL6yWyViQABOg==",
       "dev": true,
       "requires": {
-        "@types/node": "9.6.18"
+        "@types/node": "9.6.22"
       }
     },
     "@types/del": {
@@ -77,7 +77,7 @@
       "integrity": "sha512-Q3FWsbdmkQd1ib11A4XNWQvRD//5KpPoGawA8aB2DR7pWKoW9XQv3+dGxD/Z1eVFze23Okdo27ZQytVFlweKvQ==",
       "dev": true,
       "requires": {
-        "@types/node": "9.6.18"
+        "@types/node": "9.6.22"
       }
     },
     "@types/glob": {
@@ -88,7 +88,7 @@
       "requires": {
         "@types/events": "1.2.0",
         "@types/minimatch": "3.0.3",
-        "@types/node": "9.6.18"
+        "@types/node": "9.6.22"
       }
     },
     "@types/minimatch": {
@@ -103,7 +103,7 @@
       "integrity": "sha512-U5icWpv7YnZYGsN4/cmh3WD2onMY0aJIiTE6+51TwJCttdHvtCYmkBNOobHlXwrJRL0nkH9jH4kD+1FAdMN4Tg==",
       "dev": true,
       "requires": {
-        "@types/node": "9.6.18"
+        "@types/node": "9.6.22"
       }
     },
     "@types/mocha": {
@@ -113,9 +113,9 @@
       "dev": true
     },
     "@types/node": {
-      "version": "9.6.18",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-9.6.18.tgz",
-      "integrity": "sha512-lywCnJQRSsu0kitHQ5nkb7Ay/ScdJPQjhWRtuf+G1DmNKJnPcdVyP0pYvdiDFKjzReC6NLWLgSyimno3kKfIig==",
+      "version": "9.6.22",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-9.6.22.tgz",
+      "integrity": "sha512-RIg9EkxzVMkNH0M4sLRngK23f5QiigJC0iODQmu4nopzstt8AjegYund3r82iMrd2BNCjcZVnklaItvKHaGfBA==",
       "dev": true
     },
     "@types/open": {
@@ -136,7 +136,7 @@
       "integrity": "sha512-HGk753KRu2N4mWduovY4BLjYq4jTOL29gV2OfGdGxHcPSWGFkC5RRIdk+VTs5XmYd7MVAD+JwKrcb5+5Y7FOCg==",
       "dev": true,
       "requires": {
-        "@types/node": "9.6.18"
+        "@types/node": "9.6.22"
       }
     },
     "@types/tmp": {
@@ -144,6 +144,15 @@
       "resolved": "https://registry.npmjs.org/@types/tmp/-/tmp-0.0.33.tgz",
       "integrity": "sha1-EHPEvIJHVK49EM+riKsCN7qWTk0=",
       "dev": true
+    },
+    "@types/watch": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@types/watch/-/watch-1.0.0.tgz",
+      "integrity": "sha1-mSaemcFJycLaXdWu+L7l/ERYVkg=",
+      "dev": true,
+      "requires": {
+        "@types/node": "9.6.22"
+      }
     },
     "aggregate-error": {
       "version": "1.0.0",
@@ -755,6 +764,14 @@
       "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.2.tgz",
       "integrity": "sha1-Cr9PHKpbyx96nYrMbepPqqBLrJs=",
       "dev": true
+    },
+    "exec-sh": {
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/exec-sh/-/exec-sh-0.2.1.tgz",
+      "integrity": "sha512-aLt95pexaugVtQerpmE51+4QfWrNc304uez7jvj6fWnN8GeEHpttB8F36n8N7uVhUMbH/1enbxQ9HImZ4w/9qg==",
+      "requires": {
+        "merge": "1.2.0"
+      }
     },
     "expand-brackets": {
       "version": "0.1.5",
@@ -1588,6 +1605,12 @@
       "resolved": "https://registry.npmjs.org/is-utf8/-/is-utf8-0.2.1.tgz",
       "integrity": "sha1-Sw2hRCEE0bM2NA6AeX6GXPOffXI="
     },
+    "is-whitespace": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/is-whitespace/-/is-whitespace-0.3.0.tgz",
+      "integrity": "sha1-Fjnssb4DauxppUy7QBz77XEUq38=",
+      "dev": true
+    },
     "is-windows": {
       "version": "0.2.0",
       "resolved": "https://registry.npmjs.org/is-windows/-/is-windows-0.2.0.tgz",
@@ -1763,6 +1786,11 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/lowercase-keys/-/lowercase-keys-1.0.0.tgz",
       "integrity": "sha1-TjNms55/VFfjXxMkvfb4jQv8cwY="
+    },
+    "merge": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/merge/-/merge-1.2.0.tgz",
+      "integrity": "sha1-dTHjnUlJwoGma4xabgJl6LBYlNo="
     },
     "micromatch": {
       "version": "2.3.11",
@@ -2728,7 +2756,7 @@
         },
         "find-up": {
           "version": "2.1.0",
-          "resolved": false,
+          "resolved": "https://registry.npmjs.org/find-up/-/find-up-2.1.0.tgz",
           "integrity": "sha1-RdG35QbHF93UgndaK3eSCjwMV6c=",
           "dev": true,
           "requires": {
@@ -4972,12 +5000,22 @@
       "dev": true,
       "requires": {
         "arrayify-compact": "0.1.0",
+        "extract-comments": "0.7.3",
         "gfm-code-blocks": "0.2.2",
         "inflection": "1.12.0",
         "lodash": "3.10.1",
         "parse-code-context": "0.1.3"
       },
       "dependencies": {
+        "extract-comments": {
+          "version": "0.7.3",
+          "resolved": "https://registry.npmjs.org/extract-comments/-/extract-comments-0.7.3.tgz",
+          "integrity": "sha1-HF3sFzAHLFsM36VVfl9X9pJ3/DQ=",
+          "dev": true,
+          "requires": {
+            "is-whitespace": "0.3.0"
+          }
+        },
         "lodash": {
           "version": "3.10.1",
           "resolved": "https://registry.npmjs.org/lodash/-/lodash-3.10.1.tgz",
@@ -5733,6 +5771,22 @@
         "assert-plus": "1.0.0",
         "core-util-is": "1.0.2",
         "extsprintf": "1.3.0"
+      }
+    },
+    "watch": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/watch/-/watch-1.0.2.tgz",
+      "integrity": "sha1-NApxe952Vyb6CqB9ch4BR6VR3ww=",
+      "requires": {
+        "exec-sh": "0.2.1",
+        "minimist": "1.2.0"
+      },
+      "dependencies": {
+        "minimist": {
+          "version": "1.2.0",
+          "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
+          "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ="
+        }
       }
     },
     "which": {

--- a/package.json
+++ b/package.json
@@ -1,10 +1,10 @@
 {
   "name": "@google/clasp",
-  "version": "1.3.3",
+  "version": "1.4.0",
   "description": "Develop Apps Script Projects locally",
   "main": "index.js",
   "scripts": {
-    "build": "tsc --project tsconfig.json; npm i -g;",
+    "build": "npm i; tsc --project tsconfig.json; npm i -g --loglevel=error;",
     "docs": "tsc docs.ts && node docs.js",
     "lint": "tslint --project tslint.json && echo 'No lint errors. All good!'",
     "test": "nyc --cache false mocha --timeout 100000 -- tests/*.js",
@@ -59,9 +59,11 @@
     "readline": "^1.3.0",
     "recursive-readdir": "^2.2.2",
     "split-lines": "^1.1.0",
-    "url": "^0.11.0"
+    "url": "^0.11.0",
+    "watch": "^1.0.2"
   },
   "devDependencies": {
+    "@types/watch": "^1.0.0",
     "@types/anymatch": "^1.3.0",
     "@types/chai": "^4.1.3",
     "@types/cli-spinner": "^0.2.0",
@@ -73,7 +75,7 @@
     "@types/glob": "^5.0.35",
     "@types/mkdirp": "^0.5.2",
     "@types/mocha": "^5.2.0",
-    "@types/node": "^9.6.18",
+    "@types/node": "^9.6.22",
     "@types/open": "^0.0.29",
     "@types/pluralize": "^0.0.28",
     "@types/recursive-readdir": "^2.2.0",

--- a/src/files.ts
+++ b/src/files.ts
@@ -3,7 +3,17 @@ import * as anymatch from 'anymatch';
 import * as mkdirp from 'mkdirp';
 import * as recursive from 'recursive-readdir';
 import { loadAPICredentials, script } from './auth';
-import { DOT, DOTFILE, ERROR, LOG, checkIfOnline, getAPIFileType, logError, spinner } from './utils';
+import {
+  DOT,
+  DOTFILE,
+  ERROR,
+  LOG,
+  checkIfOnline,
+  getAPIFileType,
+  getProjectSettings,
+  logError,
+  spinner,
+} from './utils';
 const path = require('path');
 const readMultipleFiles = require('read-multiple-files');
 
@@ -162,6 +172,44 @@ export async function fetchProject(scriptId: string, rootDir = '', versionNumber
           // Log only filename if pulling to root (Code.gs vs ./Code.gs)
           console.log(`└─ ${rootDir ? truePath : filePath}`);
         });
+      });
+    }
+  });
+}
+
+/**
+ * Pushes project files to script.google.com.
+ */
+export async function pushFiles() {
+  const { scriptId, rootDir } = await getProjectSettings();
+  if (!scriptId) return;
+    getProjectFiles(rootDir, (err, projectFiles, files) => {
+      if(err) {
+        console.log(err);
+        spinner.stop(true);
+      } else if (projectFiles) {
+        const [nonIgnoredFilePaths] = projectFiles;
+        script.projects.updateContent({
+          scriptId,
+          resource: { files },
+        }, {}, (error: any) => {
+          spinner.stop(true);
+          if (error) {
+            logError(null, LOG.PUSH_FAILURE);
+            error.errors.map((err: any) => {
+              logError(null, err.message);
+            });
+            logError(null, LOG.FILES_TO_PUSH);
+            nonIgnoredFilePaths.map((filePath: string) => {
+              logError(null, `└─ ${filePath}`);
+            });
+            process.exit(1);
+          } else {
+            nonIgnoredFilePaths.map((filePath: string) => {
+              console.log(`└─ ${filePath}`);
+            });
+            console.log(LOG.PUSH_SUCCESS(nonIgnoredFilePaths.length));
+          }
       });
     }
   });

--- a/src/files.ts
+++ b/src/files.ts
@@ -184,8 +184,8 @@ export async function pushFiles() {
   const { scriptId, rootDir } = await getProjectSettings();
   if (!scriptId) return;
     getProjectFiles(rootDir, (err, projectFiles, files) => {
-      if(err) {
-        console.log(err);
+      if (err) {
+        logError(err, LOG.PUSH_FAILURE);
         spinner.stop(true);
       } else if (projectFiles) {
         const [nonIgnoredFilePaths] = projectFiles;

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -133,6 +133,8 @@ export const LOG = {
   STATUS_IGNORE: 'Untracked files:',
   PUSH_SUCCESS: (numFiles: number) => `Pushed ${numFiles} ${pluralize('files', numFiles)}.`,
   PUSH_FAILURE: 'Push failed. Errors:',
+  PUSH_WATCH: 'Watching for changed files...\n',
+  PUSH_WATCH_UPDATED: (filename: string) => `- Updated: ${filename}`,
   PUSHING: 'Pushing files...',
   REDEPLOY_END: 'Updated deployment.',
   REDEPLOY_START: 'Updating deployment...',


### PR DESCRIPTION
Fixes #52.

Implements a basic watch command. Caveats:
- Does not only push changed files.
- Does not check if the changed file was an ignored file.

## Demo

```
clasp push --watch
Watching for changed files...

Pushing files...
└─ appsscript.json
└─ make.gs
└─ make2.gs
└─ make5.gs
└─ test.gs
Pushed 5 files.

- Updated: make5.gs

Pushing files...
└─ appsscript.json
└─ make.gs
└─ make2.gs
└─ make5.gs
└─ test.gs
Pushed 5 files.

- Updated: test.gs

Pushing files...
└─ appsscript.json
└─ make.gs
└─ make2.gs
└─ make5.gs
└─ test.gs
Pushed 5 files.
^C
```

- [x] `npm run test` succeeds.
- [x] `npm run lint` succeeds.
- [x] Appropriate changes to README are included in PR.
