### PR TITLE
Add build-fresh script and publish script

### DIFF
--- a/README.md
+++ b/README.md
@@ -345,6 +345,8 @@ sudo npm run build;
 clasp <command>
 ```
 
+(If you see build errors, run `sudo npm run build-fresh`)
+
 #### Run Tests (experimental)
 
 Change `describe.skip(...)` to `describe(...)` for relevant tests.
@@ -369,7 +371,7 @@ Run `npm run docs` to build the "How To" section. Copy/paste that section into t
 
 1. Build `index.js` locally. `.gitignore`/`.npmignore` will hide js/ts files appropriately.
 1. Bump version: `npm version [major|minor|patch] -m "Bump version to %s"`
-1. Publish with: `npm publish --access public && git push --follow-tags`
+1. Publish with: `npm run publish`
 
 ### Contributing
 

--- a/package.json
+++ b/package.json
@@ -4,7 +4,9 @@
   "description": "Develop Apps Script Projects locally",
   "main": "index.js",
   "scripts": {
-    "build": "npm i; tsc --project tsconfig.json; npm i -g --loglevel=error;",
+    "build": "tsc --project tsconfig.json; npm i -g --loglevel=error;",
+    "build-fresh": "npm cache clean --force; npm i; npm run build;",
+    "publish": "npm publish --access public && git push --follow-tags",
     "docs": "tsc docs.ts && node docs.js",
     "lint": "tslint --project tslint.json && echo 'No lint errors. All good!'",
     "test": "nyc --cache false mocha --timeout 100000 -- tests/*.js",


### PR DESCRIPTION
Stop the bad habit of adding `npm i` to the build script. https://github.com/google/clasp/pull/226#commitcomment-29452970

Adds commands:
- `npm run build-fresh`
- `npm run publish`