### PR TITLE
Unify oauthclient usage

### DIFF
--- a/src/auth.ts
+++ b/src/auth.ts
@@ -35,18 +35,20 @@ const oauth2ClientSettings = {
 };
 const oauth2Client = new OAuth2Client(oauth2ClientSettings);
 
+// Set client for all googleapis calls
+google.options({
+  auth: oauth2Client,
+});
+
 // Google API clients
 export const script = google.script({
   version: 'v1',
-  auth: oauth2Client,
 }) as Script;
 export const logger = google.logging({
   version: 'v2',
-  auth: oauth2Client,
 }) as Logging;
 export const drive = google.drive({
   version: 'v3',
-  auth: oauth2Client,
 }) as Drive;
 
 /**

--- a/src/auth.ts
+++ b/src/auth.ts
@@ -41,15 +41,9 @@ google.options({
 });
 
 // Google API clients
-export const script = google.script({
-  version: 'v1',
-}) as Script;
-export const logger = google.logging({
-  version: 'v2',
-}) as Logging;
-export const drive = google.drive({
-  version: 'v3',
-}) as Drive;
+export const script = google.script({version: 'v1'}) as Script;
+export const logger = google.logging({version: 'v2'}) as Logging;
+export const drive = google.drive({version: 'v3'}) as Drive;
 
 /**
  * Requests authorization to manage Apps Script projects.


### PR DESCRIPTION
While doing OAuth work today, noticed we could condense this into one call.

Signed-off-by: campionfellin <campionfellin@gmail.com>

- [x] `npm run test` succeeds.
- [x] `npm run lint` succeeds.
