### PR TITLE
Fix a couple of tests

### DIFF
--- a/src/files.ts
+++ b/src/files.ts
@@ -195,13 +195,13 @@ export async function pushFiles() {
         }, {}, (error: any) => {
           spinner.stop(true);
           if (error) {
-            logError(null, LOG.PUSH_FAILURE);
+            console.error(LOG.PUSH_FAILURE);
             error.errors.map((err: any) => {
-              logError(null, err.message);
+              console.error(err.message);
             });
-            logError(null, LOG.FILES_TO_PUSH);
+            console.error(LOG.FILES_TO_PUSH);
             nonIgnoredFilePaths.map((filePath: string) => {
-              logError(null, `└─ ${filePath}`);
+              console.error(`└─ ${filePath}`);
             });
             process.exit(1);
           } else {

--- a/src/files.ts
+++ b/src/files.ts
@@ -194,6 +194,10 @@ export async function pushFiles() {
           resource: { files },
         }, {}, (error: any) => {
           spinner.stop(true);
+          // In the following code, we favor console.error()
+          // over logError() because logError() exits, whereas
+          // we want to log multiple lines of messages, and
+          // eventually exit after logging everything.
           if (error) {
             console.error(LOG.PUSH_FAILURE);
             error.errors.map((err: any) => {

--- a/tests/test.ts
+++ b/tests/test.ts
@@ -82,11 +82,14 @@ describe.skip('Test clasp clone <scriptId> function', () => {
     expect(result.status).to.equal(0);
   });
   it('should give an error on a non-existing project', () => {
+    const settings = JSON.parse(fs.readFileSync('.clasp.json', 'utf8'));
+    fs.removeSync('.clasp.json');
     const result = spawnSync(
       CLASP, ['clone', 'non-existing-project'], { encoding: 'utf8' },
     );
     expect(result.stderr).to.contain('> Did you provide the correct scriptId?');
     expect(result.status).to.equal(1);
+    fs.writeFileSync('.clasp.json', JSON.stringify(settings));
   });
 });
 


### PR DESCRIPTION
Changed `logError(...)` in a couple places back to `console.error(...)` because I noticed this test was failing:

https://github.com/google/clasp/blob/e3866dc6df21193b0412ab98e8296905f5b1386f/tests/test.ts#L117

Fixed the other test by removing the `.clasp.json` file before testing, otherwise the response would be `Project file .clasp.json already exists.`. Then re-write `.clasp.json` for use in further tests.

Signed-off-by: campionfellin <campionfellin@gmail.com>

- [x] `npm run test` succeeds.
- [x] `npm run lint` succeeds.

