### PR TITLE
Fix issue with opn library

### DIFF
--- a/src/auth.ts
+++ b/src/auth.ts
@@ -124,6 +124,7 @@ async function authorizeWithLocalhost() {
     const authUrl = client.generateAuthUrl(oauth2ClientAuthUrlOpts);
     console.log(LOG.AUTHORIZE(authUrl));
     open(authUrl);
+    process.exit(0);
   });
   server.close();
   return (await client.getToken(authCode)).tokens;

--- a/src/commands.ts
+++ b/src/commands.ts
@@ -521,5 +521,6 @@ export const openCmd = async (scriptId: any) => {
   } else {
     console.log(LOG.OPEN_PROJECT(scriptId));
     open(getScriptURL(scriptId));
+    process.exit(0);
   }
 };


### PR DESCRIPTION
Noticed this while running tests, the `open(...)` command doesn't return an exit status on MacOS (see: https://github.com/sindresorhus/opn/issues/92). 

Thus the test for `clasp open` was hanging up even though it successfully opened.

Signed-off-by: campionfellin <campionfellin@gmail.com>

- [x] `npm run test` succeeds.
- [x] `npm run lint` succeeds.
