### PR TITLE
Fix clasp login error

### DIFF
--- a/src/auth.ts
+++ b/src/auth.ts
@@ -121,7 +121,6 @@ async function authorizeWithLocalhost() {
     const authUrl = client.generateAuthUrl(oauth2ClientAuthUrlOpts);
     console.log(LOG.AUTHORIZE(authUrl));
     open(authUrl);
-    process.exit(0);
   });
   server.close();
   return (await client.getToken(authCode)).tokens;


### PR DESCRIPTION
This accidentally closes the server before the user can confirm the login.

Signed-off-by: campionfellin <campionfellin@gmail.com>

- [ ] `npm run test` succeeds.
- [x] `npm run lint` succeeds.
- [ ] Appropriate changes to README are included in PR.
