### PR TITLE
Better error logging for quota limit

### DIFF
--- a/src/utils.ts
+++ b/src/utils.ts
@@ -105,6 +105,7 @@ Forgot ${PROJECT_NAME} commands? Get help:\n  ${PROJECT_NAME} --help`,
   PAYLOAD_UNKNOWN: 'Unknown StackDriver payload.',
   PERMISSION_DENIED: `Error: Permission denied. Enable the Apps Script API:
 https://script.google.com/home/usersettings`,
+  RATE_LIMIT: 'Rate limit exceeded. Check quota.',
   SCRIPT_ID: '\n> Did you provide the correct scriptId?\n',
   SCRIPT_ID_DNE: `\nNo ${DOT.PROJECT.PATH} settings found. \`create\` or \`clone\` a project first.`,
   SCRIPT_ID_INCORRECT: (scriptId: string) => `The scriptId "${scriptId}" looks incorrect.
@@ -171,6 +172,8 @@ export const logError = (err: any, description = '') => {
     logError(null, ERROR.UNAUTHENTICATED);
   } else if (err && (err.error && err.error.code === 403 || err.code === 403)) {
     logError(null, ERROR.PERMISSION_DENIED);
+  } else if (err && err.code === 429) {
+    logError(null, ERROR.RATE_LIMIT);
   } else {
     if (err && err.error) {
       console.error(`~~ API ERROR (${err.statusCode || err.error.code})`);


### PR DESCRIPTION
Drive API seems to have a daily limit, which is hit a lot with the full tests, (`clasp create` is called 10 times for every PR).

This changes the error message from `Error creating script.` to `Rate limit exceeded. Check quota.` so that we know when this happens if builds fail.

Looks like I can request a higher quota here: https://support.google.com/code/contact/drive_quota?

but it's unclear what to put for Project ID in the form..

Signed-off-by: campionfellin <campionfellin@gmail.com>

- [ ] `npm run test` succeeds.
- [x] `npm run lint` succeeds.
- [ ] Appropriate changes to README are included in PR.
