### PR TITLE
Add note about Travis quota limits

### DIFF
--- a/tests/README.md
+++ b/tests/README.md
@@ -14,6 +14,8 @@ To run tests yourself, follow the __Local Configuration__ instructions.
 
 ## Configuration using Travis
 
+> Note: If the build is failing, it may be because of API quota limits. Wait a bit and then rebuild Travis.
+
 Travis (https://travis-ci.org/) is used to automatically build and run tests on `clasp`. Every version of `clasp` should pass the Travis build step before release.
 
 Since Travis cannot `clasp login`, a `.clasprc.json` file is included that was created locally using `clasp login`.


### PR DESCRIPTION
The Travis build occasionally fails because of API quotas.
Let's note that.