### PR TITLE
Add note about tsc dependency

### DIFF
--- a/tests/README.md
+++ b/tests/README.md
@@ -8,6 +8,8 @@ To run tests yourself, follow the __Local Configuration__ instructions.
 
 ## Local Configuration
 
+> Note: Requires `tsc` installed `npm install -g typescript`
+
 1. Make sure you are logged in (`clasp login`).
 1. Rebuild: `sudo npm run build`
 1. Run `npm run test`


### PR DESCRIPTION
Tests require `tsc` installed. State that.
EDIT: Do not merge. I believe the tests instructions issue is I was facing is not this, but simply not building clasp before testing.