### PR TITLE
fix list of files when rootDir given

### DIFF
--- a/src/files.ts
+++ b/src/files.ts
@@ -137,7 +137,12 @@ export function getProjectFiles(rootDir: string, callback: FilesCallback): void 
             // Has a type or is appsscript.json
             let isValidJSONIfJSON = true;
             if (type === 'JSON') {
-              isValidJSONIfJSON = (name === 'appsscript.json');
+              if (rootDir) {
+                isValidJSONIfJSON = (name === path.join(rootDir, 'appsscript.json'));
+              }
+              else {
+                isValidJSONIfJSON = (name === 'appsscript.json');
+              }
             } else {
               // Must be SERVER_JS or HTML.
               // https://developers.google.com/apps-script/api/reference/rest/v1/File

--- a/tests/test.ts
+++ b/tests/test.ts
@@ -215,6 +215,24 @@ describe('Test clasp status function', () => {
       'node_modules/fsevents/build/Release/.deps/Release/.node.d']);
     expect(resultJson.filesToPush).to.have.members(['appsscript.json']);
   });
+  it('should respect globs and negation rules when rootDir given', () => {
+    const tmpdir = setupTmpDirectory([
+      { file: '.clasp.json', data: '{ "scriptId":"1234", "rootDir":"dist" }' },
+      { file: '.claspignore', data: '**/**\n!dist/build/main.js\n!dist/appsscript.json' },
+      { file: 'dist/build/main.js', data: TEST_CODE_JS },
+      { file: 'dist/appsscript.json', data: TEST_JSON },
+      { file: 'dist/shouldBeIgnored', data: TEST_CODE_JS },
+      { file: 'dist/should/alsoBeIgnored', data: TEST_CODE_JS },
+    ]);
+    spawnSync(CLASP, ['create', '[TEST] clasp status'], { encoding: 'utf8', cwd: tmpdir  });
+    const result = spawnSync(CLASP, ['status', '--json'], { encoding: 'utf8', cwd: tmpdir });
+    console.log(result.stdout);
+    console.log(result.stderr);
+    expect(result.status).to.equal(0);
+    const resultJson = JSON.parse(result.stdout);
+    expect(resultJson.untrackedFiles).to.have.members(['dist/shouldBeIgnored', 'dist/should/alsoBeIgnored']);
+    expect(resultJson.filesToPush).to.have.members(['dist/build/main.js', 'dist/appsscript.json']);
+  });
 });
 
 describe('Test clasp open function', () => {


### PR DESCRIPTION
I found a problem. The appsscript.json file is ignored when rootDir is given.
Please check it.

- [x] `npm run test` succeeds.
- [x] `npm run lint` succeeds.
- [x] Appropriate changes to README are included in PR.
