### PR TITLE
Fix deploy test

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,7 +11,7 @@ node_js:
 - '6'
 env:
   global:
-    - SCRIPT_ID=1Q3zCVgK53kEiacR0qvBYFr-A4d720UgZh3cdfDF2oFVJE5SgFiXO0AVZ
+    - SCRIPT_ID=1yEDNF3n5q2abYndZeqzJBVFjrP4hhMWTeoVFE-Car9UQYc6T2b_LfjJa
 cache:
   directories:
   - "$HOME/.npm"

--- a/.travis.yml
+++ b/.travis.yml
@@ -11,7 +11,7 @@ node_js:
 - '6'
 env:
   global:
-    - SCRIPT_ID=1yEDNF3n5q2abYndZeqzJBVFjrP4hhMWTeoVFE-Car9UQYc6T2b_LfjJa
+    - SCRIPT_ID=1Q3zCVgK53kEiacR0qvBYFr-A4d720UgZh3cdfDF2oFVJE5SgFiXO0AVZ
 cache:
   directories:
   - "$HOME/.npm"

--- a/tests/test.ts
+++ b/tests/test.ts
@@ -282,8 +282,14 @@ describe('Test clasp deploy function', () => {
     const result = spawnSync(
       CLASP, ['deploy'], { encoding: 'utf8' },
     );
-    expect(result.stdout).to.contain('Created version ');
-    expect(result.status).to.equal(0);
+    if (result.stderr) {
+      expect(result.stderr).to.contain('Unable to deploy;');
+      expect(result.stderr).to.contain('Scripts may only have up to 20 versioned deployments at a time.');
+      expect(result.status).to.equal(1);
+    } else {
+      expect(result.stdout).to.contain('Created version ');
+      expect(result.status).to.equal(0);
+    }
   });
   after(cleanup);
 });


### PR DESCRIPTION
Replace the scriptId with the old one that seemed to be working.

Add logic for the `clasp deploy` test that fails at deployment limit.
