### PR TITLE
Add more tests for when running commands logged out

### DIFF
--- a/src/commands.ts
+++ b/src/commands.ts
@@ -70,7 +70,7 @@ export const push = async (cmd: {
  */
 export const help = () => {
   commander.outputHelp();
-  process.exit(1);
+  process.exit(0);
 };
 
 /**

--- a/tests/test.ts
+++ b/tests/test.ts
@@ -5,7 +5,7 @@ import * as fs from 'fs-extra';
 import { describe, it } from 'mocha';
 import * as tmp from 'tmp';
 import { getFileType } from './../src/files';
-import { getAPIFileType, getScriptURL, saveProjectId } from './../src/utils.js';
+import { getAPIFileType, getScriptURL, saveProjectId, ERROR } from './../src/utils.js';
 const { spawnSync } = require('child_process');
 const TEST_CODE_JS = 'function test() { Logger.log(\'test\'); }';
 const TEST_JSON = '{"timeZone": "America/New_York"}';
@@ -14,6 +14,7 @@ const isPR = process.env.TRAVIS_PULL_REQUEST;
 const CLASP_SETTINGS: string = JSON.stringify({
   scriptId: process.env.SCRIPT_ID,
 });
+const CLASP_USAGE = 'Usage: clasp <command> [options]';
 
 const cleanup = () => {
   fs.removeSync('.clasp.json');
@@ -445,5 +446,114 @@ describe('Test clasp logout function', () => {
     expect(localDotExists).to.equal(false);
     const dotExists = fs.existsSync('~/.clasprc.json');
     expect(dotExists).to.equal(false);
+  });
+});
+
+describe('Test clasp help function (in general)', () => {
+  it('should show help correctly', () => {
+    const result = spawnSync(
+      CLASP, ['help'], { encoding: 'utf8' },
+    );
+    expect(result.stdout).to.contain(CLASP_USAGE);
+    expect(result.status).to.equal(1);
+  });
+  it('should show help correctly', () => {
+    const result = spawnSync(
+      CLASP, ['--help'], { encoding: 'utf8' },
+    );
+    expect(result.stdout).to.contain(CLASP_USAGE);
+    expect(result.status).to.equal(0);
+  });
+  it('should show help correctly', () => {
+    const result = spawnSync(
+      CLASP, ['-h'], { encoding: 'utf8' },
+    );
+    expect(result.stdout).to.contain(CLASP_USAGE);
+    expect(result.status).to.equal(0);
+  });
+});
+describe('Test clasp version function', () => {
+  it('should show version correctly', () => {
+    const result = spawnSync(
+      CLASP, ['--version'], { encoding: 'utf8' },
+    );
+    expect(result.stdout).to.contain(require('./../package.json').version);
+    expect(result.status).to.equal(0);
+  });
+  it('should show help correctly', () => {
+    const result = spawnSync(
+      CLASP, ['-v'], { encoding: 'utf8' },
+    );
+    expect(result.stdout).to.contain(require('./../package.json').version);
+    expect(result.status).to.equal(0);
+  });
+});
+describe('Test clasp unknown function', () => {
+  it('should show version correctly', () => {
+    const result = spawnSync(
+      CLASP, ['unknown'], { encoding: 'utf8' },
+    );
+    expect(result.stderr).to.contain('🤔  Unknown command "unknown"');
+    expect(result.status).to.equal(1);
+  });
+});
+
+describe('Test all functions while logged out', () => {
+  const expectNoCredentials = (command: string) => {
+    const result = spawnSync(
+      CLASP, [command], { encoding : 'utf8' },
+    );
+    expect(result.status).to.equal(1);
+    expect(result.stderr).to.include(ERROR.NO_CREDENTIALS);
+  };
+  it('should fail to list (no credentials)', () => expectNoCredentials('list'));
+  it('should fail to clone (no credentials)', () => expectNoCredentials('clone'));
+  it('should fail to push (no credentials)', () => expectNoCredentials('push'));
+  it('should fail to deployments (no credentials)', () => expectNoCredentials('deployments'));
+  it('should fail to deploy (no credentials)', () => expectNoCredentials('deploy'));
+  it('should fail to version (no credentials)', () => expectNoCredentials('version'));
+  it('should fail to versions (no credentials)', () => expectNoCredentials('versions'));
+  // TODO: all test should have same order of checks
+  // and should all return ERROR.NO_CREDENTIALS
+  it('should pull error correctly', () => {
+    const result = spawnSync(
+      CLASP, ['pull'], { encoding: 'utf8' },
+    );
+    expect(result.status).to.equal(1);
+    // Should be ERROR.NO_CREDENTIALS
+    // see: https://github.com/google/clasp/issues/278
+    expect(result.stderr).to.contain(ERROR.SCRIPT_ID_DNE);
+  });
+  it('should open error correctly', () => {
+    const result = spawnSync(
+      CLASP, ['open'], { encoding: 'utf8' },
+    );
+    expect(result.status).to.equal(1);
+    // Should be ERROR.NO_CREDENTIALS
+    // see: https://github.com/google/clasp/issues/278
+    expect(result.stderr).to.contain(ERROR.SCRIPT_ID_DNE);
+  });
+  it('should redeploy error correctly', () => {
+    const result = spawnSync(
+      CLASP, ['redeploy', '1234'], { encoding: 'utf8' },
+    );
+    expect(result.status).to.equal(1);
+    expect(result.stderr).to.contain('error: missing required argument `version\'');
+  });
+  it('should redeploy error correctly', () => {
+    const result = spawnSync(
+      CLASP, ['redeploy'], { encoding: 'utf8' },
+    );
+    expect(result.status).to.equal(1);
+    expect(result.stderr).to.contain('error: missing required argument `deploymentId\'');
+  });
+  it('should logs error correctly', () => {
+    const result = spawnSync(
+      CLASP, ['logs'], { encoding: 'utf8' },
+    );
+    expect(result.status).to.equal(1);
+    // Should be ERROR.NO_CREDENTIALS
+    // see: https://github.com/google/clasp/issues/278
+    expect(result.stderr).to.contain(ERROR.SCRIPT_ID_DNE);
   });
 });

--- a/tests/test.ts
+++ b/tests/test.ts
@@ -449,46 +449,32 @@ describe('Test clasp logout function', () => {
   });
 });
 
-describe('Test clasp help function (in general)', () => {
-  it('should show help correctly', () => {
+describe('Test variations of clasp help', () => {
+  const expectHelp = (variation: string) => {
     const result = spawnSync(
-      CLASP, ['help'], { encoding: 'utf8' },
+      CLASP, [variation], { encoding : 'utf8' },
     );
-    expect(result.stdout).to.contain(CLASP_USAGE);
-    expect(result.status).to.equal(1);
-  });
-  it('should show help correctly', () => {
-    const result = spawnSync(
-      CLASP, ['--help'], { encoding: 'utf8' },
-    );
-    expect(result.stdout).to.contain(CLASP_USAGE);
     expect(result.status).to.equal(0);
-  });
-  it('should show help correctly', () => {
-    const result = spawnSync(
-      CLASP, ['-h'], { encoding: 'utf8' },
-    );
-    expect(result.stdout).to.contain(CLASP_USAGE);
-    expect(result.status).to.equal(0);
-  });
+    expect(result.stdout).to.include(CLASP_USAGE);
+  };
+  it('should show help for clasp help', () => expectHelp('help'));
+  it('should show help for clasp --help', () => expectHelp('--help'));
+  it('should show help for clasp -h', () => expectHelp('-h'));
 });
-describe('Test clasp version function', () => {
-  it('should show version correctly', () => {
+
+describe('Test variations of clasp --version', () => {
+  const expectVersion = (variation: string) => {
     const result = spawnSync(
-      CLASP, ['--version'], { encoding: 'utf8' },
+      CLASP, [variation], { encoding : 'utf8' },
     );
-    expect(result.stdout).to.contain(require('./../package.json').version);
     expect(result.status).to.equal(0);
-  });
-  it('should show help correctly', () => {
-    const result = spawnSync(
-      CLASP, ['-v'], { encoding: 'utf8' },
-    );
-    expect(result.stdout).to.contain(require('./../package.json').version);
-    expect(result.status).to.equal(0);
-  });
+    expect(result.stdout).to.include(require('./../package.json').version);
+  };
+  it('should show version for clasp --version', () => expectVersion('--version'));
+  it('should show version for clasp -v', () => expectVersion('-v'));
 });
-describe('Test clasp unknown function', () => {
+
+describe('Test unknown functions', () => {
   it('should show version correctly', () => {
     const result = spawnSync(
       CLASP, ['unknown'], { encoding: 'utf8' },
@@ -513,9 +499,10 @@ describe('Test all functions while logged out', () => {
   it('should fail to deploy (no credentials)', () => expectNoCredentials('deploy'));
   it('should fail to version (no credentials)', () => expectNoCredentials('version'));
   it('should fail to versions (no credentials)', () => expectNoCredentials('versions'));
+
   // TODO: all test should have same order of checks
   // and should all return ERROR.NO_CREDENTIALS
-  it('should pull error correctly', () => {
+  it('should fail to pull (no .clasp.json file)', () => {
     const result = spawnSync(
       CLASP, ['pull'], { encoding: 'utf8' },
     );
@@ -524,7 +511,7 @@ describe('Test all functions while logged out', () => {
     // see: https://github.com/google/clasp/issues/278
     expect(result.stderr).to.contain(ERROR.SCRIPT_ID_DNE);
   });
-  it('should open error correctly', () => {
+  it('should fail to open (no .clasp.json file)', () => {
     const result = spawnSync(
       CLASP, ['open'], { encoding: 'utf8' },
     );
@@ -533,21 +520,23 @@ describe('Test all functions while logged out', () => {
     // see: https://github.com/google/clasp/issues/278
     expect(result.stderr).to.contain(ERROR.SCRIPT_ID_DNE);
   });
-  it('should redeploy error correctly', () => {
+  // Skipping this, see: https://github.com/tj/commander.js/issues/840
+  it.skip('should fail to redeploy (missing argument version)', () => {
     const result = spawnSync(
       CLASP, ['redeploy', '1234'], { encoding: 'utf8' },
     );
     expect(result.status).to.equal(1);
-    expect(result.stderr).to.contain('error: missing required argument `version\'');
+    expect(result.stderr).to.contain('error: missing required argument \'version\'');
   });
-  it('should redeploy error correctly', () => {
+  // Skipping this, see: https://github.com/tj/commander.js/issues/840
+  it.skip('should fail to redeploy (missing argument deploymentId)', () => {
     const result = spawnSync(
       CLASP, ['redeploy'], { encoding: 'utf8' },
     );
     expect(result.status).to.equal(1);
-    expect(result.stderr).to.contain('error: missing required argument `deploymentId\'');
+    expect(result.stderr).to.contain('error: missing required argument \'deploymentId\'');
   });
-  it('should logs error correctly', () => {
+  it('should fail to show logs (no .clasp.json file)', () => {
     const result = spawnSync(
       CLASP, ['logs'], { encoding: 'utf8' },
     );


### PR DESCRIPTION
These tests don't add a ton of substantiative testing, but do point out a lot of things we may want to address in the future. See comments.

Signed-off-by: campionfellin <campionfellin@gmail.com>

Works on #266 

- [x] `npm run test` succeeds.
- [x] `npm run lint` succeeds.