### PR TITLE
Remove unnecessary skip to test for `clasp status`

### DIFF
--- a/tests/test.ts
+++ b/tests/test.ts
@@ -218,8 +218,7 @@ describe('Test clasp status function', () => {
     expect(resultJson.untrackedFiles).to.have.members(['shouldBeIgnored', 'should/alsoBeIgnored']);
     expect(resultJson.filesToPush).to.have.members(['build/main.js', 'appsscript.json']);
   });
-  // https://github.com/google/clasp/issues/67 - This test currently fails
-  it.skip('should ignore dotfiles if the parent folder is ignored', () => {
+  it('should ignore dotfiles if the parent folder is ignored', () => {
     const tmpdir = setupTmpDirectory([
       { file: '.claspignore', data: '**/node_modules/**\n**/**\n!appsscript.json' },
       { file: 'appsscript.json', data: TEST_JSON },


### PR DESCRIPTION
Fixes #67  (it's a good idea to open an issue first for discussion)

- [x] `npm run test` succeeds.
- [x] `npm run lint` succeeds.
- [ ] Appropriate changes to README are included in PR.

Now, Test case `should ignore dotfiles if the parent folder is ignored` pass.
