### PR TITLE
Implement clasp apis to give example

### DIFF
--- a/src/commands.ts
+++ b/src/commands.ts
@@ -575,6 +575,10 @@ export const apis = async () => {
     list,
     enable: () => {console.log('In development...');},
     disable: () => {console.log('In development...');},
+    undefined: () => {console.log(`Try:
+    clasp apis list
+    clasp apis enable abusiveexperiencereport:v1
+    clasp apis disable abusiveexperiencereport:v1`);},
   };
   if (command[subcommand]) {
     command[subcommand]();

--- a/src/commands.ts
+++ b/src/commands.ts
@@ -576,9 +576,7 @@ export const apis = async () => {
     enable: () => {console.log('In development...');},
     disable: () => {console.log('In development...');},
     undefined: () => {console.log(`Try:
-    clasp apis list
-    clasp apis enable abusiveexperiencereport:v1
-    clasp apis disable abusiveexperiencereport:v1`);},
+    clasp apis list`);},
   };
   if (command[subcommand]) {
     command[subcommand]();

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -82,7 +82,7 @@ export const DOTFILE = {
 export const ERROR = {
   ACCESS_TOKEN: `Error retrieving access token: `,
   BAD_CREDENTIALS_FILE: 'Incorrect credentials file format.',
-  COMMAND_DNE: (command: string) => `🤔  Unknown command "${command}"\n
+  COMMAND_DNE: (command: string) => `🤔  Unknown command "${PROJECT_NAME} ${command}"\n
 Forgot ${PROJECT_NAME} commands? Get help:\n  ${PROJECT_NAME} --help`,
   CONFLICTING_FILE_EXTENSION: (name: string) => `File names: ${name}.js/${name}.gs conflict. Only keep one.`,
   CREATE: 'Error creating script.',

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -82,7 +82,7 @@ export const DOTFILE = {
 export const ERROR = {
   ACCESS_TOKEN: `Error retrieving access token: `,
   BAD_CREDENTIALS_FILE: 'Incorrect credentials file format.',
-  COMMAND_DNE: (command: string) => `🤔  Unknown command "${PROJECT_NAME} ${command}"\n
+  COMMAND_DNE: (command: string) => `🤔  Unknown command "${command}"\n
 Forgot ${PROJECT_NAME} commands? Get help:\n  ${PROJECT_NAME} --help`,
   CONFLICTING_FILE_EXTENSION: (name: string) => `File names: ${name}.js/${name}.gs conflict. Only keep one.`,
   CREATE: 'Error creating script.',

--- a/tests/test.ts
+++ b/tests/test.ts
@@ -454,7 +454,7 @@ describe('Test clasp apis functions', () => {
       CLASP, ['apis', 'unknown'], { encoding: 'utf8' },
     );
     expect(result.status).to.equal(1);
-    expect(result.stderr).to.contain('Unknown command "clasp apis unknown"');
+    expect(result.stderr).to.contain('Unknown command "apis unknown"');
   });
 });
 
@@ -503,7 +503,7 @@ describe('Test unknown functions', () => {
     const result = spawnSync(
       CLASP, ['unknown'], { encoding: 'utf8' },
     );
-    expect(result.stderr).to.contain('🤔  Unknown command "clasp unknown"');
+    expect(result.stderr).to.contain('🤔  Unknown command "unknown"');
     expect(result.status).to.equal(1);
   });
 });

--- a/tests/test.ts
+++ b/tests/test.ts
@@ -421,7 +421,7 @@ describe('Test saveProjectId function from utils', () => {
 describe('Test clasp apis functions', () => {
   it('should list apis correctly', () => {
     const result = spawnSync(
-      'clasp', ['apis', 'list'], { encoding: 'utf8' },
+      CLASP, ['apis', 'list'], { encoding: 'utf8' },
     );
     expect(result.status).to.equal(0);
     expect(result.stdout).to.contain('abusiveexperiencereport   - abusiveexperiencereport:v1');
@@ -429,24 +429,34 @@ describe('Test clasp apis functions', () => {
   });
   it('should enable apis correctly', () => {
     const result = spawnSync(
-      'clasp', ['apis', 'enable'], { encoding: 'utf8' },
+      CLASP, ['apis', 'enable'], { encoding: 'utf8' },
     );
     expect(result.status).to.equal(0);
     expect(result.stdout).to.contain('In development...');
   });
   it('should disable apis correctly', () => {
     const result = spawnSync(
-      'clasp', ['apis', 'disable'], { encoding: 'utf8' },
+      CLASP, ['apis', 'disable'], { encoding: 'utf8' },
     );
     expect(result.status).to.equal(0);
     expect(result.stdout).to.contain('In development...');
   });
+  it('should show suggestions for using clasp apis', () => {
+    const result = spawnSync(
+      CLASP, ['apis'], { encoding: 'utf8' },
+    );
+    expect(result.status).to.equal(0);
+    expect(result.stdout).to.contain(`Try:
+    clasp apis list
+    clasp apis enable abusiveexperiencereport:v1
+    clasp apis disable abusiveexperiencereport:v1`);
+  });
   it('should error with unknown subcommand', () => {
     const result = spawnSync(
-      'clasp', ['apis', 'unknown'], { encoding: 'utf8' },
+      CLASP, ['apis', 'unknown'], { encoding: 'utf8' },
     );
     expect(result.status).to.equal(1);
-    expect(result.stderr).to.contain('Unknown command "apis unknown"');
+    expect(result.stderr).to.contain('Unknown command "clasp apis unknown"');
   });
 });
 
@@ -495,7 +505,7 @@ describe('Test unknown functions', () => {
     const result = spawnSync(
       CLASP, ['unknown'], { encoding: 'utf8' },
     );
-    expect(result.stderr).to.contain('🤔  Unknown command "unknown"');
+    expect(result.stderr).to.contain('🤔  Unknown command "clasp unknown"');
     expect(result.status).to.equal(1);
   });
 });

--- a/tests/test.ts
+++ b/tests/test.ts
@@ -447,9 +447,7 @@ describe('Test clasp apis functions', () => {
     );
     expect(result.status).to.equal(0);
     expect(result.stdout).to.contain(`Try:
-    clasp apis list
-    clasp apis enable abusiveexperiencereport:v1
-    clasp apis disable abusiveexperiencereport:v1`);
+    clasp apis list`);
   });
   it('should error with unknown subcommand', () => {
     const result = spawnSync(


### PR DESCRIPTION
Give example for `clasp apis` when no third argument give.
Also fixes up some testing.

Note, Travis tests will fail for:

  Test clasp status function
    1) should respect globs and negation rules
    2) should ignore dotfiles if the parent folder is ignored

Due to previous commit https://github.com/google/clasp/commit/7ac278cf0fbeaa35f7f2af9a33ac488f96427583

Signed-off-by: campionfellin <campionfellin@gmail.com>

Fixes #273 

- [ ] `npm run test` succeeds.
- [x] `npm run lint` succeeds.
- [ ] Appropriate changes to README are included in PR.
