### PR TITLE
Fix unknown command message

### DIFF
--- a/src/utils.ts
+++ b/src/utils.ts
@@ -82,7 +82,7 @@ export const DOTFILE = {
 export const ERROR = {
   ACCESS_TOKEN: `Error retrieving access token: `,
   BAD_CREDENTIALS_FILE: 'Incorrect credentials file format.',
-  COMMAND_DNE: (command: string) => `🤔  Unknown command "${command}"\n
+  COMMAND_DNE: (command: string) => `🤔  Unknown command "${PROJECT_NAME} ${command}"\n
 Forgot ${PROJECT_NAME} commands? Get help:\n  ${PROJECT_NAME} --help`,
   CONFLICTING_FILE_EXTENSION: (name: string) => `File names: ${name}.js/${name}.gs conflict. Only keep one.`,
   CREATE: 'Error creating script.',

--- a/tests/test.ts
+++ b/tests/test.ts
@@ -5,7 +5,14 @@ import * as fs from 'fs-extra';
 import { describe, it } from 'mocha';
 import * as tmp from 'tmp';
 import { getFileType } from './../src/files';
-import { ERROR, getAPIFileType, getScriptURL, getWebApplicationURL, saveProjectId } from './../src/utils.js';
+import {
+  ERROR,
+  getAPIFileType,
+  getScriptURL,
+  getWebApplicationURL,
+  saveProjectId,
+  PROJECT_NAME,
+} from './../src/utils.js';
 const { spawnSync } = require('child_process');
 const TEST_CODE_JS = 'function test() { Logger.log(\'test\'); }';
 const TEST_JSON = '{"timeZone": "America/New_York"}';
@@ -454,7 +461,7 @@ describe('Test clasp apis functions', () => {
       CLASP, ['apis', 'unknown'], { encoding: 'utf8' },
     );
     expect(result.status).to.equal(1);
-    expect(result.stderr).to.contain('Unknown command "apis unknown"');
+    expect(result.stderr).to.contain(`Unknown command "${PROJECT_NAME} apis unknown"`);
   });
 });
 
@@ -503,7 +510,7 @@ describe('Test unknown functions', () => {
     const result = spawnSync(
       CLASP, ['unknown'], { encoding: 'utf8' },
     );
-    expect(result.stderr).to.contain('🤔  Unknown command "unknown"');
+    expect(result.stderr).to.contain(`🤔  Unknown command "${PROJECT_NAME} unknown"`);
     expect(result.status).to.equal(1);
   });
 });


### PR DESCRIPTION
Unknown commands now give `Unknown command "clasp command"` instead of `Unknown command "command"`

Signed-off-by: campionfellin <campionfellin@gmail.com>

- [ ] `npm run test` succeeds.
- [x] `npm run lint` succeeds.
- [ ] Appropriate changes to README are included in PR.
