### PR TITLE
Add the ability to specify the local server's listening port.

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,6 +94,9 @@ Logs the user in. Saves the client credentials to an rc file.
 - `--no-localhost`: Do not run a local server, manually enter code instead.
 - `--ownkey`: Save .clasprc.json file to current working directory.
 
+##### Environment Variables
+- CLASP_AUTH_PORT - Clasp uses a random port when running the local server. If you need to set the port explicity you can use this environment variable to set it. Ex: CLASP_AUTH_PORT=9000.
+
 ### Logout
 
 Logs out the user by deleting client credentials.

--- a/src/auth.ts
+++ b/src/auth.ts
@@ -102,7 +102,7 @@ async function authorizeWithLocalhost() {
   // the server port needed to set up the Oauth2Client.
   const server = await new Promise<http.Server>((resolve, _) => {
     const s = http.createServer();
-    s.listen(0, () => resolve(s));
+    s.listen(process.env.CLASP_AUTH_PORT || 0, () => resolve(s));
   });
   const port = (server.address() as AddressInfo).port; // (Cast from <string | AddressInfo>)
   const client = new OAuth2Client({


### PR DESCRIPTION
Fixes #34
- [ X ] `npm run test` succeeds.
- [ X ] `npm run lint` succeeds.
- [ X ] Appropriate changes to README are included in PR.
