### PR TITLE
Add clasp logs --setup functionality

### DIFF
--- a/src/commands.ts
+++ b/src/commands.ts
@@ -303,7 +303,6 @@ export const logs = async (cmd: {
   const data = logs.data;
   if (!data) return logError(logs.statusText, 'Unable to query StackDriver logs');
   printLogs(data.entries);
-
 };
 
 /**

--- a/src/index.ts
+++ b/src/index.ts
@@ -251,7 +251,7 @@ commander
   .action(list);
 
 /**
- * Prints out 5 most recent the StackDriver logs.
+ * Prints out the StackDriver logs.
  * @name logs
  * @param {boolean?} json Output logs in json format.
  * @param {boolean?} open Open StackDriver logs in a browser.
@@ -261,6 +261,7 @@ commander
   .description('Shows the StackDriver logs')
   .option('--json', 'Show logs in JSON form')
   .option('--open', 'Open the StackDriver logs in browser')
+  .option('--setup', 'Setup StackDriver logs')
   .action(logs);
 
 /**

--- a/src/index.ts
+++ b/src/index.ts
@@ -251,7 +251,7 @@ commander
   .action(list);
 
 /**
- * Prints out the StackDriver logs.
+ * Prints StackDriver logs.
  * @name logs
  * @param {boolean?} json Output logs in json format.
  * @param {boolean?} open Open StackDriver logs in a browser.

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -99,9 +99,6 @@ Forgot ${PROJECT_NAME} commands? Get help:\n  ${PROJECT_NAME} --help`,
   NO_CREDENTIALS: 'Could not read API credentials. Are you logged in?',
   NO_WEBAPP: (deploymentId: string) => `Deployment "${deploymentId}" is not deployed as WebApp.`,
   NO_FUNCTION_NAME: 'N/A',
-  NO_GCLOUD_PROJECT: `\nPlease set your projectId in your .clasp.json file to your Google Cloud project ID. \n
-  You can find your projectId by following the instructions in the README here: \n
-  https://github.com/google/clasp#get-project-id`,
   NO_NESTED_PROJECTS: '\nNested clasp projects are not supported.',
   READ_ONLY_DELETE: 'Unable to delete read-only deployment.',
   PAYLOAD_UNKNOWN: 'Unknown StackDriver payload.',
@@ -109,9 +106,10 @@ Forgot ${PROJECT_NAME} commands? Get help:\n  ${PROJECT_NAME} --help`,
 https://script.google.com/home/usersettings`,
   RATE_LIMIT: 'Rate limit exceeded. Check quota.',
   SCRIPT_ID: '\n> Did you provide the correct scriptId?\n',
-  SCRIPT_ID_DNE: `\nNo ${DOT.PROJECT.PATH} settings found. \`create\` or \`clone\` a project first.`,
+  SCRIPT_ID_DNE: `No scriptId found in your ${DOT.PROJECT.PATH} file.`,
   SCRIPT_ID_INCORRECT: (scriptId: string) => `The scriptId "${scriptId}" looks incorrect.
 Did you provide the correct scriptId?`,
+  SETTINGS_DNE: `\nNo ${DOT.PROJECT.PATH} settings found. \`create\` or \`clone\` a project first.`,
   UNAUTHENTICATED: 'Error: Unauthenticated request: Please try again.',
 };
 
@@ -134,9 +132,12 @@ export const LOG = {
   FILES_TO_PUSH: 'Files to push were:',
   FINDING_SCRIPTS: 'Finding your scripts...',
   FINDING_SCRIPTS_DNE: 'No script files found.',
+  LOGS_SETUP: 'Finished setting up logs.\n',
+  NO_GCLOUD_PROJECT: `No projectId found. Running ${PROJECT_NAME} logs --setup.`,
   OPEN_PROJECT: (scriptId: string) => `Opening script: ${scriptId}`,
   OPEN_WEBAPP: (deploymentId: string) => `Opening web application: ${deploymentId}`,
   PULLING: 'Pulling files...',
+  SCRIPT_LINK: (scriptId: string) => `https://script.google.com/d/${scriptId}/edit \n`,
   STATUS_PUSH: 'Not ignored files:',
   STATUS_IGNORE: 'Ignored files:',
   PUSH_SUCCESS: (numFiles: number) => `Pushed ${numFiles} ${pluralize('files', numFiles)}.`,
@@ -222,7 +223,7 @@ export function getProjectSettings(failSilently?: boolean): Promise<ProjectSetti
   const promise = new Promise<ProjectSettings>((resolve, reject) => {
     const fail = (failSilently?: boolean) => {
       if (!failSilently) {
-        logError(null, ERROR.SCRIPT_ID_DNE);
+        logError(null, ERROR.SETTINGS_DNE);
         reject();
       }
       resolve();

--- a/tests/test.ts
+++ b/tests/test.ts
@@ -481,6 +481,28 @@ describe('Test clasp apis functions', () => {
   });
 });
 
+describe('Test clasp logs function', () => {
+  before(function() {
+    if (isPR !== 'false') {
+      this.skip();
+    }
+    setup();
+  });
+  it('should prompt for logs setup', () => {
+    const result = spawnSync(
+      CLASP, ['logs', '--setup'], { encoding: 'utf8' },
+    );
+    expect(result.status).to.equal(0);
+    expect(result.stdout).to.contain('Open this link:');
+    const scriptId = JSON.parse(CLASP_SETTINGS).scriptId;
+    expect(result.stdout).to.include(`https://script.google.com/d/${scriptId}/edit`);
+    expect(result.stdout).to.contain('Go to *Resource > Cloud Platform Project...*');
+    expect(result.stdout).to.include('and copy your projectId\n(including "project-id-")');
+    expect(result.stdout).to.contain('What is your GCP projectId?');
+  });
+  after(cleanup);
+});
+
 describe('Test clasp logout function', () => {
   it('should logout correctly', () => {
     fs.writeFileSync('.clasprc.json', TEST_JSON);
@@ -556,7 +578,7 @@ describe('Test all functions while logged out', () => {
     expect(result.status).to.equal(1);
     // Should be ERROR.NO_CREDENTIALS
     // see: https://github.com/google/clasp/issues/278
-    expect(result.stderr).to.contain(ERROR.SCRIPT_ID_DNE);
+    expect(result.stderr).to.contain(ERROR.SETTINGS_DNE);
   });
   it('should fail to open (no .clasp.json file)', () => {
     const result = spawnSync(
@@ -565,7 +587,7 @@ describe('Test all functions while logged out', () => {
     expect(result.status).to.equal(1);
     // Should be ERROR.NO_CREDENTIALS
     // see: https://github.com/google/clasp/issues/278
-    expect(result.stderr).to.contain(ERROR.SCRIPT_ID_DNE);
+    expect(result.stderr).to.contain(ERROR.SETTINGS_DNE);
   });
   // Skipping this, see: https://github.com/tj/commander.js/issues/840
   it.skip('should fail to redeploy (missing argument version)', () => {
@@ -590,6 +612,6 @@ describe('Test all functions while logged out', () => {
     expect(result.status).to.equal(1);
     // Should be ERROR.NO_CREDENTIALS
     // see: https://github.com/google/clasp/issues/278
-    expect(result.stderr).to.contain(ERROR.SCRIPT_ID_DNE);
+    expect(result.stderr).to.contain(ERROR.SETTINGS_DNE);
   });
 });


### PR DESCRIPTION
Adds interactive way to setup `clasp logs`:

![aug-26-2018 16-13-19](https://user-images.githubusercontent.com/11984923/44634184-1123cb80-a94b-11e8-848e-eb8584a61a08.gif)
![aug-26-2018 16-13-47](https://user-images.githubusercontent.com/11984923/44634185-12ed8f00-a94b-11e8-8dc0-3357c35053f5.gif)


Signed-off-by: campionfellin <campionfellin@gmail.com>

Fixes #294

- [x] `npm run test` succeeds.
- [x] `npm run lint` succeeds.
- [ ] Appropriate changes to README are included in PR.
