### PR TITLE
Add `--version` option to pull command

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,7 +72,7 @@ clasp
 - [`clasp logout`](#logout)
 - [`clasp create [scriptTitle] [scriptParentId] [--rootDir]`](#create)
 - [`clasp clone <scriptId>`](#clone)
-- [`clasp pull`](#pull)
+- [`clasp pull [--version]`](#pull)
 - [`clasp push [--watch]`](#push)
 - [`clasp open [scriptId] [--webapp]`](#open)
 - [`clasp deployments`](#deployments)
@@ -136,9 +136,14 @@ Clones the script from script.google.com
 Fetches a project from either a provided or saved script id.
 Updates local files with Apps Script project.
 
+#### Options
+
+- `version`: The version number of the project to retrieve.
+
 #### Examples
 
 - `clasp pull`
+- `clasp pull --version 23`
 
 ### Push
 

--- a/src/commands.ts
+++ b/src/commands.ts
@@ -31,13 +31,17 @@ const padEnd = require('string.prototype.padend');
 
 /**
  * Force downloads all Apps Script project files into the local filesystem.
+ * @param cmd.version {number} The version number of the project to retrieve.
+ *                             If not provided, the project's HEAD version is returned.
  */
-export const pull = async () => {
+export const pull = async (cmd: {
+  version: number;
+}) => {
   await checkIfOnline();
   const { scriptId, rootDir } = await getProjectSettings();
   if (scriptId) {
     spinner.setSpinnerTitle(LOG.PULLING);
-    fetchProject(scriptId, rootDir);
+    fetchProject(scriptId, rootDir, cmd.version);
   }
 };
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -122,6 +122,7 @@ commander
 commander
   .command('pull')
   .description('Fetch a remote project')
+  .option('--version <version>', 'The version number of the project to retrieve.')
   .action(pull);
 
 /**
@@ -303,12 +304,6 @@ commander
   .action(help);
 
 /**
- * Displays clasp version
- */
-commander
-.version(require('../package.json').version, '-v, --version');
-
-/**
  * All other commands are given a help message.
  * @example random
  */
@@ -322,5 +317,20 @@ if (!process.argv.slice(2).length) {
   commander.outputHelp();
 }
 
+const versionOption = Symbol('version');
+/**
+ * Displays clasp version
+ */
+commander
+  .option('-v, --version')
+  .on('option:version', () => {
+    commander[versionOption] = true;
+  });
+
 // User input is provided from the process' arguments
 commander.parse(process.argv);
+
+// Specified `--version` option with no sub-command
+if (commander[versionOption] && !commander.args[0]) {
+  console.log(require('../package.json').version);
+}


### PR DESCRIPTION
Fixes #305
- [x] `npm run test` succeeds.
- [x] `npm run lint` succeeds.
- [x] Appropriate changes to README are included in PR.

I stopped using `commander.version()`, because `--version` option with `pull` sub-command and  `--version` option with no sub-command was conflicted. 
When it is conflicted, I received output following to:

```
$ clasp pull --version 23
1.5.3
```