### PR TITLE
Use console.log instead of alert

### DIFF
--- a/docs/typescript.md
+++ b/docs/typescript.md
@@ -92,7 +92,7 @@ let notSure: any = 4;
 notSure = "maybe a string instead";
 notSure = false; // okay, definitely a boolean
 function showMessage(data: string): void { // Void
- alert(data);
+ console.log(data);
 }
 showMessage('hello');
 


### PR DESCRIPTION
Because alert doesn't work in Apps Script.

- [x] `npm run test` succeeds.
- [x] `npm run lint` succeeds.
- [x] Appropriate changes to README are included in PR.
