### PR TITLE
PR-files-rootdir-bug

### DIFF
--- a/src/files.ts
+++ b/src/files.ts
@@ -63,10 +63,10 @@ export function hasProject(): boolean {
  *   result: string[][], List of two lists of strings, ie. [nonIgnoredFilePaths,ignoredFilePaths]
  *   files?: Array<AppsScriptFile|undefined> Array of AppsScriptFile objects used by clasp push
  */
-export function getProjectFiles(rootDir: string = path.join('.', '/'), callback: FilesCallback): void {
+export function getProjectFiles(rootDir = '', callback: FilesCallback): void {
   // Read all filenames as a flattened tree
   // Note: filePaths contain relative paths such as "test/bar.ts", "../../src/foo.js"
-  recursive(rootDir, (err, filePaths) => {
+  recursive(rootDir || path.join('.', '/'), (err, filePaths) => {
     if (err) return callback(err, null, null);
     // Filter files that aren't allowed.
     DOTFILE.IGNORE().then((ignorePatterns: string[]) => {
@@ -122,7 +122,7 @@ export function getProjectFiles(rootDir: string = path.join('.', '/'), callback:
           // Preserves subdirectory names in rootDir
           // (rootDir/foo/Code.js becomes foo/Code.js)
           let formattedName = nameWithoutExt;
-          if (rootDir) {
+          if (rootDir && rootDir !== './' /* Extra check just in case so filename not mangled */) {
             formattedName = nameWithoutExt.slice(
               rootDir.length + 1,
               nameWithoutExt.length,


### PR DESCRIPTION
- [X] `npm run test` succeeds.
- [X] `npm run lint` succeeds.
- [ ] Appropriate changes to README are included in PR.

## Incremental subset of changes from [PR #313](https://github.com/google/clasp/pull/313)

### Changes
- **`files`**
  - Fxed file name mangling bug when `rootDir = './'`  in `getProjectFiles()` introduced by [9297b98](https://github.com/google/clasp/commit/9297b98df6c2c11033319b4e440a1fef0ebc84ee)
