### PR TITLE
PR-save-new-project

### DIFF
--- a/src/commands.ts
+++ b/src/commands.ts
@@ -20,7 +20,7 @@ import {
   getWebApplicationURL,
   logError,
   manifestExists,
-  saveProject,
+  saveNewProject,
   spinner,
 } from './utils';
 const open = require('opn');
@@ -130,7 +130,7 @@ export const create = async (title: string, parentId: string, cmd: {
       const createdScriptId = res.data.scriptId;
       console.log(LOG.CREATE_PROJECT_FINISH(createdScriptId));
       const rootDir = cmd.rootDir;
-      saveProject(createdScriptId, rootDir);
+      saveNewProject(createdScriptId, rootDir);
       if (!manifestExists()) {
         fetchProject(createdScriptId, rootDir); // fetches appsscript.json, o.w. `push` breaks
       }
@@ -181,7 +181,7 @@ export const clone = async (scriptId: string, versionNumber?: number) => {
         }]).then((answers: any) => {
           checkIfOnline();
           spinner.setSpinnerTitle(LOG.CLONING);
-          saveProject(answers.scriptId);
+          saveNewProject(answers.scriptId);
           fetchProject(answers.scriptId, '', versionNumber);
         }).catch((err: any) => {
           console.log(err);
@@ -191,7 +191,7 @@ export const clone = async (scriptId: string, versionNumber?: number) => {
       }
     } else {
       spinner.setSpinnerTitle(LOG.CLONING);
-      saveProject(scriptId);
+      saveNewProject(scriptId);
       fetchProject(scriptId, '', versionNumber);
     }
   }

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -287,7 +287,7 @@ export async function checkIfOnline() {
  * @param  {string} scriptId The script ID
  * @param  {string} rootDir Local root directory that store your project files
  */
-export async function saveProject(scriptId: string, rootDir?: string): Promise<ProjectSettings> {
+export async function saveNewProject(scriptId: string, rootDir?: string): Promise<ProjectSettings> {
   const project: ProjectSettings = { scriptId };
   project.rootDir = project.rootDir || rootDir;
   return DOTFILE.PROJECT().write(project);

--- a/tests/test.ts
+++ b/tests/test.ts
@@ -11,7 +11,7 @@ import {
   getAPIFileType,
   getScriptURL,
   getWebApplicationURL,
-  saveProject,
+  saveNewProject,
   getDefaultProjectName,
 } from './../src/utils.js';
 const { spawnSync } = require('child_process');
@@ -434,11 +434,11 @@ describe('Test getAPIFileType function from utils', () => {
   });
 });
 
-describe('Test saveProject function from utils', () => {
+describe('Test saveNewProject function from utils', () => {
   it('should save the scriptId correctly', () => {
     spawnSync('rm', ['.clasp.json']);
     const isSaved = async () => {
-      await saveProject('12345');
+      await saveNewProject('12345');
       const id = fs.readFileSync(path.join(__dirname, '/../.clasp.json'), 'utf8');
       expect(id).to.equal('{"scriptId":"12345"}');
     };
@@ -448,7 +448,7 @@ describe('Test saveProject function from utils', () => {
   it('should save the scriptId, rootDir correctly', () => {
     spawnSync('rm', ['.clasp.json']);
     const isSaved = async () => {
-      await saveProject('12345', './dist');
+      await saveNewProject('12345', './dist');
       const id = fs.readFileSync(path.join(__dirname, '/../.clasp.json'), 'utf8');
       expect(id).to.equal('{"scriptId":"12345","rootDir":"./dist"}');
     };


### PR DESCRIPTION
- [X] `npm run test` succeeds.
- [X] `npm run lint` succeeds.
- [ ] Appropriate changes to README are included in PR.

## Incremental subset of changes from [PR #313](https://github.com/google/clasp/pull/313)

### Changes
- **`utils`**
  - `saveProject()` renamed `saveNewProject()` to clarify as not all project settings are from ProjectSettings iface are preserved
- **test**
  - *Test saveNewProject function from utils*: saveProject=>saveNewProject