### PR TITLE
Modify clasp open command to print script URL

### DIFF
--- a/src/utils.ts
+++ b/src/utils.ts
@@ -218,7 +218,7 @@ export const LOG = {
   FINDING_SCRIPTS: 'Finding your scripts...',
   GRAB_LOGS: 'Grabbing logs...',
   LOCAL_CREDS: `Using local credentials: ${DOT.RC.LOCAL_DIR}${DOT.RC.NAME} 🔐 `,
-  OPEN_PROJECT: (scriptId: string) => `Opening script: ${scriptId}`,
+  OPEN_PROJECT: (scriptId: string) => `Opening script: ${URL.SCRIPT(scriptId)}`,
   OPEN_WEBAPP: (deploymentId: string) => `Opening web application: ${deploymentId}`,
   PULLING: 'Pulling files...',
   PUSH_FAILURE: 'Push failed. Errors:',


### PR DESCRIPTION
Fixes #314. Simple one-line change to have the project's URL printed out instead of just the ID.

- [x] `npm run test` succeeds.
- [x] `npm run lint` succeeds.
