### PR TITLE
Fix SAVED_LOCAL_CREDS message

### DIFF
--- a/src/utils.ts
+++ b/src/utils.ts
@@ -231,7 +231,7 @@ export const LOG = {
   REDEPLOY_END: 'Updated deployment.',
   REDEPLOY_START: 'Updating deployment...',
   SAVED_CREDS: `Default credentials saved to: ${DOT.RC.PATH} (${DOT.RC.ABSOLUTE_PATH}).`,
-  SAVED_LOCAL_CREDS: `Local credentials saved to: ${DOT.RC.LOCAL_DIR}${DOT.RC.NAME}.`,
+  SAVED_LOCAL_CREDS: `Local credentials saved to: ${DOT.RC.LOCAL_DIR}${DOT.RC.ABSOLUTE_LOCAL_PATH}.`,
   SCRIPT_LINK: (scriptId: string) => `https://script.google.com/d/${scriptId}/edit \n`,
   SCRIPT_RUN: (functionName: string) => `Executing: ${functionName}`,
   STACKDRIVER_SETUP: 'Setting up StackDriver Logging.',


### PR DESCRIPTION
- [x] `npm run test` succeeds.
- [x] `npm run lint` succeeds.
- [x] Appropriate changes to README are included in PR.

It is different from the actual path and it was fixed.

Current:
```
Authorization successful.
Local credentials saved to: ./clasprc.json.
```

After:
```
Authorization successful.
Local credentials saved to: ./.clasprc.json.
```

