### PR TITLE
Add creds option to login command in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,7 +68,7 @@ sudo npm i -g grpc @google/clasp --unsafe-perm
 ```sh
 clasp
 ```
-- [`clasp login [--no-localhost]`](#login)
+- [`clasp login [--no-localhost] [--creds <file>]`](#login)
 - [`clasp logout`](#logout)
 - [`clasp create [scriptTitle] [scriptParentId] [--rootDir]`](#create)
 - [`clasp clone <scriptId>`](#clone)


### PR DESCRIPTION
In detail the option was missing.
https://github.com/google/clasp#login

- [ ] `npm run test` succeeds.
- [x] `npm run lint` succeeds.
- [x] Appropriate changes to README are included in PR.
