### PR TITLE
Fix pull version option name

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,7 +72,7 @@ clasp
 - [`clasp logout`](#logout)
 - [`clasp create [scriptTitle] [scriptParentId] [--rootDir]`](#create)
 - [`clasp clone <scriptId>`](#clone)
-- [`clasp pull [--version]`](#pull)
+- [`clasp pull [--versionNumber]`](#pull)
 - [`clasp push [--watch]`](#push)
 - [`clasp open [scriptId] [--webapp]`](#open)
 - [`clasp deployments`](#deployments)
@@ -138,12 +138,12 @@ Updates local files with Apps Script project.
 
 #### Options
 
-- `version`: The version number of the project to retrieve.
+- `versionNumber`: The version number of the project to retrieve.
 
 #### Examples
 
 - `clasp pull`
-- `clasp pull --version 23`
+- `clasp pull --versionNumber 23`
 
 ### Push
 

--- a/src/commands.ts
+++ b/src/commands.ts
@@ -38,13 +38,13 @@ const padEnd = require('string.prototype.padend');
  *                             If not provided, the project's HEAD version is returned.
  */
 export const pull = async (cmd: {
-  version: number;
+  versionNumber: number;
 }) => {
   await checkIfOnline();
   const { scriptId, rootDir } = await getProjectSettings();
   if (scriptId) {
     spinner.setSpinnerTitle(LOG.PULLING);
-    fetchProject(scriptId, rootDir, cmd.version);
+    fetchProject(scriptId, rootDir, cmd.versionNumber);
   }
 };
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -122,7 +122,7 @@ commander
 commander
   .command('pull')
   .description('Fetch a remote project')
-  .option('--version <version>', 'The version number of the project to retrieve.')
+  .option('--versionNumber <version>', 'The version number of the project to retrieve.')
   .action(pull);
 
 /**


### PR DESCRIPTION
In the specification of 'commander', the option with the same name does
not seem to work properly.
It seems that `cmd.version` is always undefined.

Therefore, I changed the pull option name.

Fixes #339 

- [x] `npm run test` succeeds.
- [x] `npm run lint` succeeds.
- [x] Appropriate changes to README are included in PR.
