### PR TITLE
Enable to select URL for clasp open --webapp

### DIFF
--- a/src/commands.ts
+++ b/src/commands.ts
@@ -690,6 +690,7 @@ export const status = async (cmd: { json: boolean }) => {
 /**
  * Opens an Apps Script project's script.google.com editor.
  * @param scriptId {string} The Apps Script project to open.
+ * @param cmd.open {boolean} If true, the command will open the webapps URL.
  */
 export const openCmd = async (scriptId: any, cmd: { webapp: boolean }) => {
   await checkIfOnline();
@@ -714,10 +715,27 @@ export const openCmd = async (scriptId: any, cmd: { webapp: boolean }) => {
     if (!deployments.length) {
       logError(null, ERROR.SCRIPT_ID_INCORRECT(scriptId));
     } else {
-      deployments.sort((d1: any, d2: any) => d1.updateTime.localeCompare(d2.updateTime));
-      const deployment = deployments[deployments.length - 1];
-      console.log(LOG.OPEN_WEBAPP(deployment.deploymentId));
-      open(getWebApplicationURL(deployment), { wait: false });
+      const choices = deployments
+        .sort((d1: any, d2: any) => d1.updateTime.localeCompare(d2.updateTime))
+        .map((deployment:any) => {
+          const DESC_PAD_SIZE = 30;
+          const id = deployment.deploymentId;
+          const description = deployment.deploymentConfig.description;
+          const versionNumber = deployment.deploymentConfig.versionNumber;
+          return {
+            name: padEnd(ellipsize(description || '', DESC_PAD_SIZE), DESC_PAD_SIZE)
+                    + `@${padEnd(versionNumber || 'HEAD', 4)} - ${id}`,
+            value: deployment,
+          };
+        });
+      const answers = await prompt([{
+        type: 'list',
+        name: 'deployment',
+        message: 'Open which deployment?',
+        choices,
+      }]);
+      console.log(LOG.OPEN_WEBAPP(answers.deployment.deploymentId));
+      open(getWebApplicationURL(answers.deployment), { wait: false });
     }
   }
 };

--- a/tests/test.ts
+++ b/tests/test.ts
@@ -343,12 +343,11 @@ describe('Test clasp open function', () => {
     }
     setup();
   });
-  it('should open a project correctly', () => {
+  it('should prompt for which deployment to open correctly', () => {
     const result = spawnSync(
       CLASP, ['open'], { encoding: 'utf8' },
     );
-    //should open a browser with the project
-    expect(result.status).to.equal(0);
+    expect(result.stdout).to.contain('Clone which deployment?');
   });
   after(cleanup);
 });


### PR DESCRIPTION
Fixes #346 
- [x] `npm run test` succeeds.
- [x] `npm run lint` succeeds.
- [ ] Appropriate changes to README are included in PR.
