### PR TITLE
Add setting command to update .clasp.json

### DIFF
--- a/README.md
+++ b/README.md
@@ -326,6 +326,21 @@ Displays the help function.
 
 - `clasp help`
 
+### Setting
+
+Update .clasp.json settings file.
+If `newValue` is omitted it returns the current setting value
+
+#### Options
+
+- `settingKey`: settingKey They key in .clasp.json you want to change
+- `newValue`: newValue The new value for the setting
+
+#### Examples
+
+- `clasp setting scriptId`
+- `clasp setting scriptId new-id`
+
 ## Guides
 
 ### [Get Project ID](#get-project-id)

--- a/src/commands.ts
+++ b/src/commands.ts
@@ -896,4 +896,4 @@ export const setting = async (settingKey: keyof ProjectSettings, settingValue?: 
       logError(null, 'Unable to update .clasp.json');
     }
   }
-}
+};

--- a/src/index.ts
+++ b/src/index.ts
@@ -43,6 +43,7 @@ import {
   undeploy,
   version,
   versions,
+  setting,
 } from './commands';
 import { PROJECT_NAME } from './utils';
 
@@ -309,6 +310,20 @@ commander
   .command('help')
   .description('Display help')
   .action(help);
+
+/**
+ * Update .clasp.json settings file.
+ * If `newValue` is omitted it returns the current setting value
+ * @name setting
+ * @param {string} settingKey They key in .clasp.json you want to change
+ * @param {string?} newValue The new value for the setting
+ * @example setting scriptId
+ * @example setting scriptId new-id
+ */
+commander
+  .command('setting <settingKey> [newValue]')
+  .description('Update <settingKey> in .clasp.json')
+  .action(setting);
 
 /**
  * All other commands are given a help message.

--- a/tests/test.ts
+++ b/tests/test.ts
@@ -452,6 +452,47 @@ describe('Test clasp clone function', () => {
   after(cleanup);
 });
 
+describe('Test setting function', () => {
+  before(function() {
+    if (isPR !== 'false') {
+      this.skip();
+    }
+    setup();
+  });
+  it('should return current setting value', () => {
+    const result = spawnSync(
+      CLASP, ['setting', 'scriptId'], { encoding: 'utf8' },
+    );
+
+    expect(result.stdout).to.equal(process.env.SCRIPT_ID);
+  });
+  it('should update .clasp.json with provided value', () => {
+    const result = spawnSync(
+      CLASP, ['setting', 'scriptId', 'test'], { encoding: 'utf8' },
+    );
+    const fileContents = fs.readFileSync('.clasp.json', 'utf8');
+    expect(result.stdout).to.contain('Updated "scriptId":');
+    expect(result.stdout).to.contain('-> "test"');
+    expect(fileContents).to.contain('"test"');
+  });
+  it('should error on unknown keys', () => {
+    // Test getting
+    let result = spawnSync(
+      CLASP, ['setting', 'foo'], { encoding: 'utf8' },
+    );
+    expect(result.status).to.equal(1);
+    expect(result.stderr).to.contain('Unknown key "foo"');
+
+    // Test setting
+    result = spawnSync(
+      CLASP, ['setting', 'bar', 'foo'], { encoding: 'utf8' },
+    );
+    expect(result.status).to.equal(1);
+    expect(result.stderr).to.contain('Setting "bar" is unsupported');
+  });
+  after(cleanup);
+});
+
 describe('Test getAppsScriptFileName function from files', () => {
   it('should return the basename correctly', () => {
     expect(getAppsScriptFileName('./', 'appsscript.json')).to.equal('appsscript');


### PR DESCRIPTION
Addresses #349 by adding a `clasp setting` command

- [x] `npm run test` succeeds.
- [x] `npm run lint` succeeds.
- [x] Appropriate changes to README are included in PR.

The last commit (b6c4db8) has introduced a build error for me, so this is based off the previous commit (c1d1f0a). It also works with a [quick patch](https://github.com/arichardsmith/clasp/commit/aea5e1f9dcd80a7f55536557d85883783a7a58f9) to b6c4db8.

Let me know what you think.