### PR TITLE
Make global creds isLocal false

### DIFF
--- a/src/auth.ts
+++ b/src/auth.ts
@@ -160,7 +160,7 @@ export async function authorize(options: {
       claspToken = {
         token,
         oauth2ClientSettings: globalOauth2ClientSettings,
-        isLocalCreds: true,
+        isLocalCreds: false,
       };
       await DOTFILE.RC.write(claspToken);
     }


### PR DESCRIPTION
When saving globally, should be `isLocalCreds` false.

Signed-off-by: campionfellin <campionfellin@gmail.com>

Fixes #356 

### Did not do below steps, because they are already broken. Will be fixing in follow up PRs.

- [ ] `npm run test` succeeds.
- [ ] `npm run lint` succeeds.
- [ ] Appropriate changes to README are included in PR.
