### PR TITLE
Migrate `clasp redeploy` and `clasp version` to inquirer functionality

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,7 +83,7 @@ clasp
 - [`clasp deployments`](#deployments)
 - [`clasp deploy [version] [description]`](#deploy)
 - [`clasp undeploy <deploymentId>`](#undeploy)
-- [`clasp redeploy <deploymentId> <version> <description>`](#redeploy)
+- [`clasp redeploy [deploymentId] [version] [description]`](#redeploy)
 - [`clasp version [description]`](#version)
 - [`clasp versions`](#versions)
 - [`clasp list`](#list)
@@ -256,6 +256,9 @@ Updates deployments of a script.
 
 #### Examples
 
+- `clasp redeploy`
+- `clasp redeploy 123`
+- `clasp redeploy 123 3`
 - `clasp redeploy 123 3 "Why I updated the deployment"`
 
 ### Version

--- a/src/commands.ts
+++ b/src/commands.ts
@@ -675,8 +675,8 @@ export const redeploy = async (deploymentId: string, version: string, descriptio
     const choices =  data.versions.reverse().map((version: any) => {
       return {
         name: LOG.VERSION_DESCRIPTION(version),
-        value: version
-      }
+        value: version,
+      };
     });
     const answers = await prompt([{
       type: 'list',

--- a/src/commands.ts
+++ b/src/commands.ts
@@ -778,6 +778,15 @@ export const version = async (description: string) => {
   await loadAPICredentials();
   spinner.setSpinnerTitle(LOG.VERSION_CREATE).start();
   const { scriptId } = await getProjectSettings();
+  if(!description){
+    const answers = await prompt([{
+      type: 'input',
+      name: 'description',
+      message: 'Give a description:',
+      default: '',
+    }]);
+    description = answers.description;
+  }
   const versions = await script.projects.versions.create({
     scriptId,
     requestBody: {

--- a/src/commands.ts
+++ b/src/commands.ts
@@ -686,6 +686,15 @@ export const redeploy = async (deploymentId: string, version: string, descriptio
     }]);
     version = answers.version.versionNumber;
   }
+  if(!description){
+    const answers = await prompt([{
+      type: 'input',
+      name: 'description',
+      message: 'Give a description:',
+      default: '',
+    }]);
+    description = answers.description;
+  }
   const deployments = await script.projects.deployments.update({
     scriptId,
     deploymentId,

--- a/src/commands.ts
+++ b/src/commands.ts
@@ -635,7 +635,7 @@ export const redeploy = async (deploymentId: string, version: string, descriptio
       return logError(null, ERROR.SCRIPT_ID_INCORRECT(scriptId));
     }
     const choices = deployments
-      .filter((deployment: any) => deployment.deploymentConfig.versionNumber!==undefined)
+      .filter((deployment: any) => deployment.deploymentConfig.versionNumber !== undefined)
       .sort((d1: any, d2: any) => d1.updateTime.localeCompare(d2.updateTime))
       .map((deployment: any) => {
         const DESC_PAD_SIZE = 30;

--- a/src/index.ts
+++ b/src/index.ts
@@ -209,13 +209,13 @@ commander
 /**
  * Updates deployments of a script.
  * @name redeploy
- * @param {number} deploymentId The deployment ID.
- * @param {number} version The target deployment version.
- * @param {string} description The reason why the script was redeployed.
+ * @param {number?} deploymentId The deployment ID.
+ * @param {number?} version The target deployment version.
+ * @param {string?} description The reason why the script was redeployed.
  * @example redeploy 123 3 "Why I updated the deployment"
  */
 commander
-  .command('redeploy <deploymentId> <version> <description>')
+  .command('redeploy [deploymentId] [version] [description]')
   .description(`Update a deployment`)
   .action(redeploy);
 


### PR DESCRIPTION
Fixes #57 

If you do not specify an argument, we use `inquirer` to ask it.

- [ ] `npm run test` succeeds.
- [x] `npm run lint` succeeds.
- [x] Appropriate changes to README are included in PR.

I am not good at English.
Sorry for any inconvenience.