### PR TITLE
Switch `deploymentId` of `clasp undeploy` to optional

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,7 +82,7 @@ clasp
 - [`clasp open [scriptId] [--webapp]`](#open)
 - [`clasp deployments`](#deployments)
 - [`clasp deploy [--versionNumber <version>] [--desc <description>] [--deploymentId <id>]`](#deploy)
-- [`clasp undeploy <deploymentId>`](#undeploy)
+- [`clasp undeploy [deploymentId]`](#undeploy)
 - [`clasp redeploy [deploymentId] [version] [description]`](#redeploy)
 - [`clasp version [description]`](#version)
 - [`clasp versions`](#versions)
@@ -241,10 +241,11 @@ Undeploys a deployment of a script.
 
 #### Options
 
-- `deploymentId`: deploymentId The deployment ID.
+- `deploymentId`: An optional deployment ID.
 
 #### Examples
 
+- `clasp undeploy` (undeploy the last deployment.)
 - `clasp undeploy "123"`
 
 ### Redeploy

--- a/src/commands.ts
+++ b/src/commands.ts
@@ -598,10 +598,10 @@ export const undeploy = async (deploymentId: string) => {
     if (!deployments.length) {
       logError(null, ERROR.SCRIPT_ID_INCORRECT(scriptId));
     }
-    if(deployments.length<=1) { // @HEAD (Read-only deployments) may not be deleted.
-      logError(null, ERROR.NO_VERSIONED_DEPLOYMENTS)
+    if(deployments.length <= 1) { // @HEAD (Read-only deployments) may not be deleted.
+      logError(null, ERROR.NO_VERSIONED_DEPLOYMENTS);
     }
-    deploymentId = deployments[deployments.length-1].deploymentId || '';
+    deploymentId = deployments[deployments.length - 1].deploymentId || '';
   }
   spinner.setSpinnerTitle(LOG.UNDEPLOYMENT_START(deploymentId)).start();
   const deployment = await script.projects.deployments.delete({

--- a/src/index.ts
+++ b/src/index.ts
@@ -201,11 +201,12 @@ commander
 /**
  * Undeploys a deployment of a script.
  * @name undeploy
- * @param {string} deploymentId The deployment ID.
+ * @param {string?} [deploymentId] The deployment ID.
+ * @example "undeploy" (undeploy the last deployment.)
  * @example "undeploy 123"
  */
 commander
-  .command('undeploy <deploymentId>')
+  .command('undeploy [deploymentId]')
   .description('Undeploy a deployment of a project')
   .action(undeploy);
 

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -105,6 +105,7 @@ Forgot ${PROJECT_NAME} commands? Get help:\n  ${PROJECT_NAME} --help`,
   NO_MANIFEST: (filename: string) =>
     `Manifest: ${filename} invalid. \`create\` or \`clone\` a project first.`,
   NO_NESTED_PROJECTS: '\nNested clasp projects are not supported.',
+  NO_VERSIONED_DEPLOYMENTS: `No versioned deployments found in project.`,
   NO_WEBAPP: (deploymentId: string) => `Deployment "${deploymentId}" is not deployed as WebApp.`,
   OFFLINE: 'Error: Looks like you are offline.',
   ONE_DEPLOYMENT_CREATE: 'Currently just one deployment can be created at a time.',


### PR DESCRIPTION
If you do not enter `deploymentId`, the latest deploymentId will be used.

This PR follows the design of https://github.com/google/clasp/pull/372#issuecomment-435435683 .

- [ ] `npm run test` succeeds.
- [x] `npm run lint` succeeds.
- [x] Appropriate changes to README are included in PR.

