### PR TITLE
Recursively checking clasprc.json

### DIFF
--- a/src/auth.ts
+++ b/src/auth.ts
@@ -156,7 +156,7 @@ export async function authorize(options: {
         },
         isLocalCreds: true,
       };
-      await DOTFILE.RC_LOCAL.write(claspToken);
+      await DOTFILE.RC_LOCAL().write(claspToken);
     } else {
       // Save global ClaspCredentials.
       claspToken = {
@@ -280,7 +280,7 @@ async function setOauthCredentials(rc: ClaspToken) {
     await refreshCredentials(globalOAuth2Client);
 
     // Save the credentials.
-    await (rc.isLocalCreds ? DOTFILE.RC_LOCAL : DOTFILE.RC).write(rc);
+    await (rc.isLocalCreds ? DOTFILE.RC_LOCAL() : DOTFILE.RC).write(rc);
   } catch (err) {
     logError(null, ERROR.ACCESS_TOKEN + err);
   }

--- a/src/dotfile.ts
+++ b/src/dotfile.ts
@@ -63,6 +63,7 @@ export const DOT = {
     DIR: '~',
     LOCAL_DIR: './',
     NAME: `${PROJECT_NAME}rc.json`,
+    LOCAL_PATH: `.${PROJECT_NAME}rc.json`,
     PATH: path.join('~', `.${PROJECT_NAME}rc.json`),
     ABSOLUTE_PATH: path.join(os.homedir(), `.${PROJECT_NAME}rc.json`),
     ABSOLUTE_LOCAL_PATH: path.join('.', `.${PROJECT_NAME}rc.json`),
@@ -98,7 +99,10 @@ export const DOTFILE = {
   // Stores {ClaspCredentials}
   RC: dotf(DOT.RC.DIR, DOT.RC.NAME),
   // Stores {ClaspCredentials}
-  RC_LOCAL: dotf(DOT.RC.LOCAL_DIR, DOT.RC.NAME),
+  RC_LOCAL: () => {
+    const localDirectory: string = findParentDir.sync(process.cwd(), DOT.RC.LOCAL_PATH) || DOT.RC.LOCAL_DIR;
+    return dotf(localDirectory, DOT.RC.NAME);
+  },
 };
 
 /**

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -49,7 +49,7 @@ export const hasOauthClientSettings = (local = false): boolean =>
  * @returns {Promise<ClaspToken>} A promise to get the rc file as object.
  */
 export function getOAuthSettings(): Promise<ClaspToken> {
-  return DOTFILE.RC_LOCAL.read()
+  return DOTFILE.RC_LOCAL().read()
     .then((rc: ClaspToken) => rc)
     .catch((err: any) => {
       return DOTFILE.RC.read()


### PR DESCRIPTION
Fixes #215

Change `DOTFILE.RC_LOCAL` to a method for recursively check.

- [x] `npm run test` succeeds.
- [x] `npm run lint` succeeds.
- [x] Appropriate changes to README are included in PR.

