### PR TITLE
update dotf(v1.0.3->v1.1.2)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -860,9 +860,9 @@
       }
     },
     "dotf": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/dotf/-/dotf-1.0.3.tgz",
-      "integrity": "sha512-kikLA2u9ugiISSMI+x6LUxwKTZTI8fOHPQu4jmPtN98+X9REfz9ZMljgvMGER68ojVPIKEdrJUDPWDgfycWvNw==",
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/dotf/-/dotf-1.1.2.tgz",
+      "integrity": "sha512-7K1gXYM/yWnK0eJ2U+SajvdpelUN/NwsFabBelHd4rRUpqSn0+Yl5R6Gu4fu0I6odwfN83ZrF8QmbymyAhVj3Q==",
       "requires": {
         "jsonfile": "^3.0.1",
         "resolve-file": "^0.3.0",
@@ -4877,7 +4877,7 @@
     },
     "os-homedir": {
       "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/os-homedir/-/os-homedir-1.0.2.tgz",
+      "resolved": "http://registry.npmjs.org/os-homedir/-/os-homedir-1.0.2.tgz",
       "integrity": "sha1-/7xJiDNuDoM94MFox+8VISGqf7M="
     },
     "os-tmpdir": {

--- a/package.json
+++ b/package.json
@@ -45,7 +45,7 @@
     "commander": "^2.15.1",
     "connect": "^3.6.6",
     "del": "^3.0.0",
-    "dotf": "^1.0.3",
+    "dotf": "^1.1.2",
     "ellipsize": "^0.1.0",
     "find-parent-dir": "^0.3.0",
     "fs": "^0.0.1-security",


### PR DESCRIPTION
Fix #387 
Update dotf (v1.0.3 -> v1.1.2).  
See:
https://github.com/grant/dotf/pull/4  
https://github.com/grant/dotf/pull/6

- [x] `npm run test` succeeds.
- [x] `npm run lint` succeeds.
- [x] Appropriate changes to README are included in PR.
