### PR TITLE
Add "Apps Script Libraries and TypeScript" to docs/typescript.md

### DIFF
--- a/docs/typescript.md
+++ b/docs/typescript.md
@@ -227,10 +227,10 @@ If you see outdated TypeScript types, you can help update them by contributing t
 ### How to Generate Types
 
 1. Fork [DefinitelyTyped/DefinitelyTyped](https://github.com/DefinitelyTyped/DefinitelyTyped)
-2. Run the types generator by following the instructions at [motemen/dts-google-apps-script](https://github.com/motemen/dts-google-apps-script)
-3. Copy the type files to your fork of `DefinitelyTyped/DefinitelyTyped`.
-4. View the diff (`git diff`), and make sure that the types look OK.
-5. Make a PR and ask [@grant](https://github.com/grant) for review.
+1. Run the types generator by following the instructions at [motemen/dts-google-apps-script](https://github.com/motemen/dts-google-apps-script)
+1. Copy the type files to your fork of `DefinitelyTyped/DefinitelyTyped`.
+1. View the diff (`git diff`), and make sure that the types look OK.
+1. Make a PR and ask [@grant](https://github.com/grant) for review.
 
 > (Eventually I'll configure a system to auto-update these types.)
 

--- a/docs/typescript.md
+++ b/docs/typescript.md
@@ -204,6 +204,20 @@ Advanced Service currently do not have TypeScript autocompletion.
 
 Currently, `clasp` supports [`typescript@2.9.2`](https://www.npmjs.com/package/typescript/v/2.9.2). If there is a feature in a newer  TypeScript version that you'd like to support, or some experimental flag you'd like enabled, please file a bug.
 
+### Apps Script Libraries and TypeScript
+
+If your project contains libraries referenced in `appsscript.json`, TypeScript will throw errors for the library names or types it cannot resolve, e.g. `[ts] Cannot find name 'OAuth2'. [2304]`. Libraries have their own types and are not part of `@types/google-apps-script`. These libraries are only resolved once the script is deployed upstream with `clasp push`.
+
+One workaround for this error is to ignore the line causing the TypeScript error by adding a line comment `// @ts-ignore` above the line. This can be done as so:
+
+```
+function getOAuthService() {
+    // Ignore OAuth2 library resolution when working locally with clasp and TypeScript
+    // @ts-ignore
+    return OAuth2.createService('Auth0');
+}
+```
+
 ## Outdated Types
 
 TypeScript types for Apps Script are currently generated manually.
@@ -213,10 +227,10 @@ If you see outdated TypeScript types, you can help update them by contributing t
 ### How to Generate Types
 
 1. Fork [DefinitelyTyped/DefinitelyTyped](https://github.com/DefinitelyTyped/DefinitelyTyped)
-1. Run the types generator by following the instructions at [motemen/dts-google-apps-script](https://github.com/motemen/dts-google-apps-script)
-1. Copy the type files to your fork of `DefinitelyTyped/DefinitelyTyped`.
-1. View the diff (`git diff`), and make sure that the types look OK.
-1. Make a PR and ask [@grant](https://github.com/grant) for review.
+2. Run the types generator by following the instructions at [motemen/dts-google-apps-script](https://github.com/motemen/dts-google-apps-script)
+3. Copy the type files to your fork of `DefinitelyTyped/DefinitelyTyped`.
+4. View the diff (`git diff`), and make sure that the types look OK.
+5. Make a PR and ask [@grant](https://github.com/grant) for review.
 
 > (Eventually I'll configure a system to auto-update these types.)
 


### PR DESCRIPTION
Documentation update with possible workaround for #392

Add section on library type workaround with @ts-ignore. No code changes, markdown file changes only.

Sorry for all the headaches with the other messed up PR's! :)