### PR TITLE
Ask project type using inquirer

### DIFF
--- a/src/commands.ts
+++ b/src/commands.ts
@@ -136,7 +136,7 @@ export const create = async (cmd: {
       type: 'list',
       name: 'type',
       message: 'Clone which script? ',
-      choices: Object.keys(SCRIPT_TYPES).map((key)=>SCRIPT_TYPES[key as any]),
+      choices: Object.keys(SCRIPT_TYPES).map((key) => SCRIPT_TYPES[key as any]),
     }]);
     type = answers.type;
   }

--- a/src/commands.ts
+++ b/src/commands.ts
@@ -128,8 +128,18 @@ export const create = async (cmd: {
 
   // Create defaults.
   const title = cmd.title || getDefaultProjectName();
-  const { type } = cmd;
+  let { type } = cmd;
   let { parentId } = cmd;
+
+  if(!type){
+    const answers = await prompt([{
+      type: 'list',
+      name: 'type',
+      message: 'Clone which script? ',
+      choices: Object.keys(SCRIPT_TYPES).map((key)=>SCRIPT_TYPES[key as any]),
+    }]);
+    type = answers.type;
+  }
 
   // Create files with MIME type.
   // https://developers.google.com/drive/api/v3/mime-types


### PR DESCRIPTION
Fixes #57 

Using inquirer if --type isn't specified.

See also : #373 

- [x] `npm run test` succeeds.
- [x] `npm run lint` succeeds.
- [x] Appropriate changes to README are included in PR.
