### PR TITLE
Clean imports and getAPIFileType

### DIFF
--- a/src/auth.ts
+++ b/src/auth.ts
@@ -1,27 +1,16 @@
 /**
  * Authentication with Google's APIs.
  */
-import * as http from 'http';
-import { AddressInfo } from 'net';
-import * as url from 'url';
 import { Credentials, OAuth2Client } from 'google-auth-library';
 import { OAuth2ClientOptions } from 'google-auth-library/build/src/auth/oauth2client';
 import { discovery_v1, drive_v3, google, logging_v2, script_v1, serviceusage_v1 } from 'googleapis';
+import * as http from 'http';
 import { prompt } from 'inquirer';
-import {
-  ClaspToken,
-  DOTFILE,
-} from './dotfile';
-import {readManifest} from './manifest';
-import {
-  ClaspCredentials,
-  ERROR,
-  LOG,
-  URL,
-  checkIfOnline,
-  getOAuthSettings,
-  logError,
-} from './utils';
+import { AddressInfo } from 'net';
+import * as url from 'url';
+import { ClaspToken, DOTFILE } from './dotfile';
+import { readManifest } from './manifest';
+import { checkIfOnline, ClaspCredentials, ERROR, getOAuthSettings, LOG, logError, URL } from './utils';
 import open = require('opn');
 import readline = require('readline');
 

--- a/src/commands.ts
+++ b/src/commands.ts
@@ -1,10 +1,10 @@
 /**
  * Clasp command method bodies.
  */
-import { readFileSync } from 'fs';
 import chalk from 'chalk';
 import * as commander from 'commander';
 import * as del from 'del';
+import { readFileSync } from 'fs';
 import { script_v1 } from 'googleapis';
 import * as pluralize from 'pluralize';
 import { watchTree } from 'watch';
@@ -23,21 +23,22 @@ import { DOT, DOTFILE, ProjectSettings } from './dotfile';
 import { fetchProject, getProjectFiles, hasProject, pushFiles } from './files';
 import { enableOrDisableAdvanceServiceInManifest, manifestExists, readManifest } from './manifest';
 import {
-  ERROR,
-  LOG,
-  PROJECT_MANIFEST_BASENAME,
-  URL,
   checkIfOnline,
+  ERROR,
   getDefaultProjectName,
   getProjectId,
   getProjectSettings,
   getWebApplicationURL,
   hasOauthClientSettings,
+  LOG,
   logError,
+  PROJECT_MANIFEST_BASENAME,
   saveProject,
   spinner,
+  URL,
   validateManifest,
 } from './utils';
+
 const ellipsize = require('ellipsize');
 const open = require('opn');
 const inquirer = require('inquirer');

--- a/src/dotfile.ts
+++ b/src/dotfile.ts
@@ -12,13 +12,13 @@
  * This should be the only file that uses DOTFILE.
  */
 import * as fs from 'fs';
-import * as os from 'os';
 import { Credentials } from 'google-auth-library';
 import { OAuth2ClientOptions } from 'google-auth-library/build/src/auth/oauth2client';
+import * as os from 'os';
+import * as path from 'path';
 
 const dotf = require('dotf');
 const read = require('read-file');
-const path = require('path');
 const findParentDir = require('find-parent-dir');
 const splitLines = require('split-lines');
 

--- a/src/files.ts
+++ b/src/files.ts
@@ -1,21 +1,13 @@
 import * as fs from 'fs';
-import * as anymatch from 'anymatch';
 import * as mkdirp from 'mkdirp';
 import * as multimatch from 'multimatch';
+import * as path from 'path';
 import * as recursive from 'recursive-readdir';
 import { loadAPICredentials, script } from './auth';
 import { DOT, DOTFILE } from './dotfile';
-import {
-  ERROR,
-  LOG,
-  checkIfOnline,
-  getAPIFileType,
-  getProjectSettings,
-  logError,
-  spinner,
-} from './utils';
+import { checkIfOnline, ERROR, getAPIFileType, getProjectSettings, LOG, logError, spinner } from './utils';
+
 const ts2gas = require('ts2gas');
-const path = require('path');
 const readMultipleFiles = require('read-multiple-files');
 
 // An Apps Script API File

--- a/src/manifest.ts
+++ b/src/manifest.ts
@@ -1,8 +1,9 @@
 import * as fs from 'fs';
+import * as path from 'path';
+
 import { PUBLIC_ADVANCED_SERVICES } from './apis';
 import { DOT } from './dotfile';
-import { ERROR, PROJECT_MANIFEST_FILENAME, getProjectSettings, logError } from './utils';
-const path = require('path');
+import { ERROR, getProjectSettings, logError, PROJECT_MANIFEST_FILENAME } from './utils';
 
 /**
  * Checks if the rootDir appears to be a valid project.

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1,15 +1,13 @@
-import * as fs from 'fs';
+import chalk from 'chalk';
 import { Spinner } from 'cli-spinner';
+import * as fs from 'fs';
+import { prompt } from 'inquirer';
+import * as path from 'path';
 import * as pluralize from 'pluralize';
-import { SCRIPT_TYPES } from './apis';
 import { ClaspToken, DOT, DOTFILE, ProjectSettings } from './dotfile';
+
 const ucfirst = require('ucfirst');
-const path = require('path');
-const findParentDir = require('find-parent-dir');
-const read = require('read-file');
 const isOnline = require('is-online');
-const { prompt } = require('inquirer');
-const chalk = require('chalk');
 
 // Names / Paths
 export const PROJECT_NAME = 'clasp';
@@ -294,12 +292,12 @@ export async function getProjectSettings(failSilently?: boolean): Promise<Projec
 
 /**
  * Gets the API FileType. Assumes the path is valid.
- * @param  {string} path The file path
- * @return {string}      The API's FileType enum (uppercase), null if not valid.
+ * @param  {string} filePath  The file path
+ * @return {string}           The API's FileType enum (uppercase), null if not valid.
  */
-export function getAPIFileType(path: string): string {
-  const extension: string = path.substr(path.lastIndexOf('.') + 1).toUpperCase();
-  return (extension === 'GS' || extension === 'JS') ? 'SERVER_JS' : extension.toUpperCase();
+export function getAPIFileType(filePath: string): string {
+  const extension = filePath.substr(filePath.lastIndexOf('.') + 1).toUpperCase();
+  return (extension === 'GS' || extension === 'JS') ? 'SERVER_JS' : extension;
 }
 
 /**


### PR DESCRIPTION
Clean imports
Fix variable shadowing in getAPIFileType + no need to call toUpperCase twice + no need to type hint

- [x] `npm run test` succeeds.
- [x] `npm run lint` succeeds.
- [x] Appropriate changes to README are included in PR.

This is a prelude to an other PR coming soon (my IDE was complaining), i'm looking into enhancing the push --watch command by fixing 'TODO: Only push when a non-ignored file is changed'