### PR TITLE
Fix clasp create test

### DIFF
--- a/src/commands.ts
+++ b/src/commands.ts
@@ -136,7 +136,7 @@ export const create = async (cmd: { type: string; title: string; parentId: strin
       {
         type: 'list',
         name: 'type',
-        message: 'Clone which script? ',
+        message: LOG.CLONE_SCRIPT_QUESTION,
         choices: Object.keys(SCRIPT_TYPES).map(key => SCRIPT_TYPES[key as any]),
       },
     ]);
@@ -233,7 +233,7 @@ export const clone = async (scriptId: string, versionNumber?: number) => {
       {
         type: 'list',
         name: 'scriptId',
-        message: 'Clone which script? ',
+        message: LOG.CLONE_SCRIPT_QUESTION,
         choices: fileIds,
         pageSize: 30,
       },

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -133,6 +133,7 @@ export const LOG = {
   AUTHORIZE: (authUrl: string) => `🔑 Authorize ${PROJECT_NAME} by visiting this url:\n${authUrl}\n`,
   CLONE_SUCCESS: (fileNum: number) => `Cloned ${fileNum} ${pluralize('files', fileNum)}.`,
   CLONING: 'Cloning files...',
+  CLONE_SCRIPT_QUESTION: 'Clone which script? ',
   CREATE_DRIVE_FILE_FINISH: (filetype: string, fileid: string) =>
     `Created new ${getFileTypeName(filetype) || '(unknown type)'}: ${URL.DRIVE(fileid)}`,
   CREATE_DRIVE_FILE_START: (filetype: string) =>

--- a/tests/test.ts
+++ b/tests/test.ts
@@ -157,7 +157,7 @@ describe('Test clasp create function', () => {
     const result = spawnSync(
       CLASP, ['create'], { encoding: 'utf8' },
     );
-    expect(result.stdout).to.contain('Give a script title:');
+    expect(result.stdout).to.contain(LOG.CLONE_SCRIPT_QUESTION);
   });
   it('should not prompt for project name', () => {
     fs.writeFileSync('.clasp.json', '');


### PR DESCRIPTION
Fixes string for `clasp create` prompt test.

Signed-off-by: campionfellin <campionfellin@gmail.com>

Fixes #<issue_number_goes_here> (it's a good idea to open an issue first for discussion)

- [ ] `npm run test` succeeds.
- [x] `npm run lint` succeeds.
- [ ] Appropriate changes to README are included in PR.
