### PR TITLE
Fix clasp apis tests

### DIFF
--- a/tests/test.ts
+++ b/tests/test.ts
@@ -19,7 +19,7 @@ const copyFileSync = require('fs-copy-file-sync');
 const { spawnSync } = require('child_process');
 
 const TEST_CODE_JS = 'function test() { Logger.log(\'test\'); }';
-const TEST_JSON = '{"timeZone": "America/New_York"}';
+const TEST_APPSSCRIPT: string = JSON.stringify({timeZone: 'America/New_York'});
 const CLASP = (os.type() === 'Windows_NT') ? 'clasp.cmd' : 'clasp';
 const isPR = process.env.TRAVIS_PULL_REQUEST;
 const CLASP_SETTINGS: string = JSON.stringify({
@@ -44,6 +44,7 @@ const cleanup = () => {
 
 const setup = () => {
   fs.writeFileSync('.clasp.json', CLASP_SETTINGS);
+  fs.writeFileSync('appsscript.json', TEST_APPSSCRIPT);
 };
 
 const rndStr = () => Math.random().toString(36).substr(2);
@@ -243,7 +244,7 @@ describe('Test clasp push function', () => {
   it.skip('should push local project correctly', () => {
     fs.removeSync('.claspignore');
     fs.writeFileSync('Code.js', TEST_CODE_JS);
-    fs.writeFileSync('appsscript.json', TEST_JSON);
+    fs.writeFileSync('appsscript.json', TEST_APPSSCRIPT);
     fs.writeFileSync('.claspignore', '**/**\n!Code.js\n!appsscript.json');
     const result = spawnSync(
       CLASP, ['push'], { encoding: 'utf8' },
@@ -285,7 +286,7 @@ describe('Test clasp status function', () => {
     const tmpdir = setupTmpDirectory([
       { file: '.claspignore', data: '**/**\n!build/main.js\n!appsscript.json' },
       { file: 'build/main.js', data: TEST_CODE_JS },
-      { file: 'appsscript.json', data: TEST_JSON },
+      { file: 'appsscript.json', data: TEST_APPSSCRIPT },
       { file: 'shouldBeIgnored', data: TEST_CODE_JS },
       { file: 'should/alsoBeIgnored', data: TEST_CODE_JS },
     ]);
@@ -303,7 +304,7 @@ describe('Test clasp status function', () => {
   it('should ignore dotfiles if the parent folder is ignored', () => {
     const tmpdir = setupTmpDirectory([
       { file: '.claspignore', data: '**/node_modules/**\n**/**\n!appsscript.json' },
-      { file: 'appsscript.json', data: TEST_JSON },
+      { file: 'appsscript.json', data: TEST_APPSSCRIPT },
       { file: 'node_modules/fsevents/build/Release/.deps/Release/.node.d', data: TEST_CODE_JS },
     ]);
     spawnSync(CLASP, ['create', '[TEST] clasp status'], { encoding: 'utf8', cwd: tmpdir });
@@ -321,7 +322,7 @@ describe('Test clasp status function', () => {
       { file: '.clasp.json', data: '{ "scriptId":"1234", "rootDir":"dist" }' },
       { file: '.claspignore', data: '**/**\n!dist/build/main.js\n!dist/appsscript.json' },
       { file: 'dist/build/main.js', data: TEST_CODE_JS },
-      { file: 'dist/appsscript.json', data: TEST_JSON },
+      { file: 'dist/appsscript.json', data: TEST_APPSSCRIPT },
       { file: 'dist/shouldBeIgnored', data: TEST_CODE_JS },
       { file: 'dist/should/alsoBeIgnored', data: TEST_CODE_JS },
     ]);


### PR DESCRIPTION
`clasp apis` requires an `appsscript.json` file, otherwise throws this error:

`Manifest: appsscript.json invalid. `create` or `clone` a project first.`

Signed-off-by: campionfellin <campionfellin@gmail.com>

Fixes #<issue_number_goes_here> (it's a good idea to open an issue first for discussion)

- [ ] `npm run test` succeeds.
- [x] `npm run lint` succeeds.
- [ ] Appropriate changes to README are included in PR.
