### PR TITLE
Add dotfile to matching option

### DIFF
--- a/src/files.ts
+++ b/src/files.ts
@@ -83,7 +83,7 @@ export async function getProjectFiles(rootDir: string = path.join('.', '/'), cal
         if (abortPush) return callback(new Error(), null, null);
 
         // check ignore files
-        const ignoreMatches = multimatch(filePaths, ignorePatterns);
+        const ignoreMatches = multimatch(filePaths, ignorePatterns, { dot: true });
 
         // Loop through every file.
         const files = filePaths


### PR DESCRIPTION
Fixes #430 

Add a flag for checking dot files when matching.

- [x] `npm run test` succeeds.
- [x] `npm run lint` succeeds.
- [x] Appropriate changes to README are included in PR.
