### PR TITLE
Fix comment of getProjectId function in utils

### DIFF
--- a/src/utils.ts
+++ b/src/utils.ts
@@ -335,7 +335,7 @@ export async function saveProject(scriptId: string, rootDir?: string): Promise<P
 }
 
 /**
- * Get App Script project ID from project settings file or prompt for one.
+ * Get Clould Platform project ID of Apps Script from project settings file or prompt for one.
  * @returns {Promise<string>} A promise to get the projectId string.
  */
 export async function getProjectId(promptUser = true): Promise<string> {

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -335,7 +335,7 @@ export async function saveProject(scriptId: string, rootDir?: string): Promise<P
 }
 
 /**
- * Get Clould Platform project ID of Apps Script from project settings file or prompt for one.
+ * Gets the script's Cloud Platform Project Id from project settings file or prompt for one.
  * @returns {Promise<string>} A promise to get the projectId string.
  */
 export async function getProjectId(promptUser = true): Promise<string> {


### PR DESCRIPTION
I think that the `projectId` of the `getProjectId` function  in utils belongs to Google Cloud Platform.
Therefore I fixed the comment on it.

Related https://github.com/google/clasp/pull/433.

## TODO

- [x] `npm run test` succeeds.
- [x] `npm run lint` succeeds.
- [x] Appropriate changes to README are included in PR.