### PR TITLE
Remove support for Node7

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,9 +5,9 @@ os:
 language: node_js
 node_js:
 - node
-- '9'
-- '8'
-- '6'
+- '9' # EOL: 2018-06-30
+- '8' # EOL: December 2019
+- '6' # EOL: April 2019
 env:
   global:
   - SCRIPT_ID=1Q3zCVgK53kEiacR0qvBYFr-A4d720UgZh3cdfDF2oFVJE5SgFiXO0AVZ

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,8 +4,8 @@ os:
 - osx
 language: node_js
 node_js:
-- node
-- '9' # EOL: 2018-06-30
+- node # Node 11
+- '10' # EOL: April 2021
 - '8' # EOL: December 2019
 - '6' # EOL: April 2019
 env:

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,7 +7,6 @@ node_js:
 - node
 - '9'
 - '8'
-- '7'
 - '6'
 env:
   global:


### PR DESCRIPTION
Node7 is past end-of-life (https://github.com/nodejs/Release)

Removing it, as it was causing test failures for `clasp version` and `clasp versions`

Signed-off-by: campionfellin <campionfellin@gmail.com>

- [ ] `npm run test` succeeds.
- [x] `npm run lint` succeeds.
- [ ] Appropriate changes to README are included in PR.
