### PR TITLE
Clean up getOAuthSettings in utils

### DIFF
--- a/src/auth.ts
+++ b/src/auth.ts
@@ -187,9 +187,9 @@ export async function authorize(options: {
  * Loads the Apps Script API credentials for the CLI.
  * Required before every API call.
  */
-export async function loadAPICredentials(local = false): Promise<ClaspToken> {
+export async function loadAPICredentials(): Promise<ClaspToken> {
   // Gets the OAuth settings. May be local or global.
-  const rc: ClaspToken = await getOAuthSettings(local);
+  const rc: ClaspToken = await getOAuthSettings();
   await setOauthClientCredentials(rc);
   return rc;
 }

--- a/src/auth.ts
+++ b/src/auth.ts
@@ -187,9 +187,9 @@ export async function authorize(options: {
  * Loads the Apps Script API credentials for the CLI.
  * Required before every API call.
  */
-export async function loadAPICredentials(): Promise<ClaspToken> {
+export async function loadAPICredentials(localCredsOnly = false): Promise<ClaspToken> {
   // Gets the OAuth settings. May be local or global.
-  const rc: ClaspToken = await getOAuthSettings();
+  const rc: ClaspToken = await getOAuthSettings(localCredsOnly);
   await setOauthClientCredentials(rc);
   return rc;
 }

--- a/src/commands.ts
+++ b/src/commands.ts
@@ -598,7 +598,7 @@ export const run = async (functionName: string, cmd: { nondev: boolean }) => {
   async function runFunction(functionName: string) {
     try {
       // Load local credentials.
-      await loadAPICredentials();
+      await loadAPICredentials(true);
       const localScript = await getLocalScript();
       spinner.setSpinnerTitle(`Running function: ${functionName}`).start();
       const res = await localScript.scripts.run({

--- a/src/commands.ts
+++ b/src/commands.ts
@@ -598,7 +598,7 @@ export const run = async (functionName: string, cmd: { nondev: boolean }) => {
   async function runFunction(functionName: string) {
     try {
       // Load local credentials.
-      await loadAPICredentials(true);
+      await loadAPICredentials();
       const localScript = await getLocalScript();
       spinner.setSpinnerTitle(`Running function: ${functionName}`).start();
       const res = await localScript.scripts.run({

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -48,17 +48,25 @@ export const hasOauthClientSettings = (local = false): boolean =>
  * Should be used instead of `DOTFILE.RC?().read()`
  * @returns {Promise<ClaspToken>} A promise to get the rc file as object.
  */
-export function getOAuthSettings(): Promise<ClaspToken> {
-  return DOTFILE.RC_LOCAL()
-    .read()
-    .then((rc: ClaspToken) => rc)
-    .catch((err: any) => {
-      return DOTFILE.RC.read()
-        .then((rc: ClaspToken) => rc)
-        .catch((err: any) => {
-          logError(err, ERROR.NO_CREDENTIALS);
-        });
-    });
+export function getOAuthSettings(localCredsOnly: boolean): Promise<ClaspToken> {
+  if (localCredsOnly) {
+    return DOTFILE.RC_LOCAL().read()
+      .then((rc: ClaspToken) => rc)
+      .catch((err: any) => {
+        logError(err, ERROR.NO_CREDENTIALS(localCredsOnly));
+      });
+  } else {
+    return DOTFILE.RC_LOCAL()
+      .read()
+      .then((rc: ClaspToken) => rc)
+      .catch((err: any) => {
+        return DOTFILE.RC.read()
+          .then((rc: ClaspToken) => rc)
+          .catch((err: any) => {
+            logError(err, ERROR.NO_CREDENTIALS(localCredsOnly));
+          });
+      });
+    }
 }
 
 // Helpers to get Apps Script project URLs
@@ -99,7 +107,8 @@ Forgot ${PROJECT_NAME} commands? Get help:\n  ${PROJECT_NAME} --help`,
   LOGS_UNAVAILABLE: 'StackDriver logs are getting ready, try again soon.',
   NO_API: (enable: boolean, api: string) =>
     `API ${api} doesn\'t exist. Try \'clasp apis ${enable ? 'enable' : 'disable'} sheets\'.`,
-  NO_CREDENTIALS: `Could not read API credentials. `,
+  NO_CREDENTIALS: (local:boolean) => `Could not read API credentials. ` +
+    `Are you logged in ${local ? 'locall' : 'globall'}y?`,
   NO_FUNCTION_NAME: 'N/A',
   NO_GCLOUD_PROJECT: `No projectId found in your ${DOT.PROJECT.PATH} file.`,
   NO_LOCAL_CREDENTIALS: `Requires local crendetials:\n\n  ${PROJECT_NAME} login --creds <file.json>`,

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -48,12 +48,16 @@ export const hasOauthClientSettings = (local = false): boolean =>
  * Should be used instead of `DOTFILE.RC?().read()`
  * @returns {Promise<ClaspToken>} A promise to get the rc file as object.
  */
-export function getOAuthSettings(local: boolean): Promise<ClaspToken> {
-  const RC = (local) ? DOTFILE.RC_LOCAL() : DOTFILE.RC;
-  return RC.read()
+export function getOAuthSettings(): Promise<ClaspToken> {
+  return DOTFILE.RC_LOCAL()
+    .read()
     .then((rc: ClaspToken) => rc)
     .catch((err: any) => {
-      logError(err, ERROR.NO_CREDENTIALS(local));
+      return DOTFILE.RC.read()
+        .then((rc: ClaspToken) => rc)
+        .catch((err: any) => {
+          logError(err, ERROR.NO_CREDENTIALS);
+        });
     });
 }
 
@@ -95,8 +99,7 @@ Forgot ${PROJECT_NAME} commands? Get help:\n  ${PROJECT_NAME} --help`,
   LOGS_UNAVAILABLE: 'StackDriver logs are getting ready, try again soon.',
   NO_API: (enable: boolean, api: string) =>
     `API ${api} doesn\'t exist. Try \'clasp apis ${enable ? 'enable' : 'disable'} sheets\'.`,
-  NO_CREDENTIALS: (local:boolean) => `Could not read API credentials. ` +
-    `Are you logged in ${local ? 'locall' : 'globall'}y?`,
+  NO_CREDENTIALS: `Could not read API credentials. `,
   NO_FUNCTION_NAME: 'N/A',
   NO_GCLOUD_PROJECT: `No projectId found in your ${DOT.PROJECT.PATH} file.`,
   NO_LOCAL_CREDENTIALS: `Requires local crendetials:\n\n  ${PROJECT_NAME} login --creds <file.json>`,


### PR DESCRIPTION
The logic for `getOAuthSettings` was originally implemented a few months ago in this commit:

https://github.com/google/clasp/commit/8b65ad7978ab436bbcb461b611d60f6cead1441e

However, this recent commit: 

https://github.com/google/clasp/commit/87a481092a56b8a58d1ceee34e89b5e385b009eb

Changed some things.

My guess is this change was for `clasp run` because the global creds are not sufficient and lead to cryptic error messages, so this was needed to tell users they need local creds for `clasp run`. I think we should do it slightly differently, as we want to keep functionality of searching upward recursively.

I think maybe we can keep the boolean `local` (or change it to `onlyLocalPermitted` (i.e. they are using `clasp run`) and if that's passed as `true` then we don't go up recursively, else, normal logic.

Signed-off-by: campionfellin <campionfellin@gmail.com>

Reduces failed tests from 11 -> 3.  (see: https://travis-ci.org/campionfellin/clasp/jobs/466344222)

My guess is these 3 that are left should be fairly straightforward to fix and are related to other recent commits.