### PR TITLE
Change travis decrypt directory to HOME

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -17,7 +17,7 @@ cache:
   - "$HOME/.npm"
 before_install:
 - openssl aes-256-cbc -K $encrypted_9c710391eddd_key -iv $encrypted_9c710391eddd_iv
-  -in ./tests/.clasprc.json.enc -out .clasprc.json -d || true
+  -in ./tests/.clasprc.json.enc -out $HOME/.clasprc.json -d || true
 - npm install -g npm@latest
 install:
 - npm ci


### PR DESCRIPTION
Travis will now decrypt the `.clasprc.json` file into the `$HOME` directory,  which is used for all commands except `clasp run` (which's tests we skip right now).

Signed-off-by: campionfellin <campionfellin@gmail.com>

- [ ] `npm run test` succeeds.
- [x] `npm run lint` succeeds.
- [ ] Appropriate changes to README are included in PR.
