### PR TITLE
Fix clasp settings function

### DIFF
--- a/src/commands.ts
+++ b/src/commands.ts
@@ -1140,27 +1140,31 @@ export const setting = async (settingKey?: keyof ProjectSettings, settingValue?:
       // Which interfers with storing the value
       process.stdout.write(keyValue);
     } else {
-      logError(null, `Value not found for "${settingKey}"`); // TODO LOG
+      logError(null, ERROR.UNKNOWN_KEY(settingKey));
     }
   } else {
     try {
       const currentSettings = await getProjectSettings();
       const currentValue = settingKey in currentSettings ? currentSettings[settingKey] : '';
-
-      // TODO Add all keys dynamically
-      const scriptId = settingKey === 'scriptId' ? settingValue : currentSettings.scriptId;
-      const rootDir = settingKey === 'rootDir' ? settingValue : currentSettings.rootDir;
-      const projectId = settingKey === 'projectId' ? settingValue : currentSettings.projectId;
-      const fileExtension = settingKey === 'fileExtension' ? settingValue : currentSettings.fileExtension;
+      switch(settingKey) {
+        case 'scriptId':
+          currentSettings.scriptId = settingValue;
+          break;
+        case 'rootDir':
+          currentSettings.rootDir = settingValue;
+          break;
+        case 'projectId':
+          currentSettings.projectId = settingValue;
+          break;
+        case 'fileExtension':
+          currentSettings.fileExtension = settingValue;
+          break;
+        default:
+          logError(null, ERROR.UNKNOWN_KEY(settingKey));
+      }
       // filePushOrder doesn't work since it requires an array.
       // const filePushOrder = settingKey === 'filePushOrder' ? settingValue : currentSettings.filePushOrder;
-      await saveProject({
-        scriptId,
-        rootDir,
-        projectId,
-        fileExtension,
-        // filePushOrder,
-      }, true);
+      await saveProject(currentSettings, true);
       console.log(`Updated "${settingKey}": "${currentValue}" → "${settingValue}"`);
     } catch (e) {
       logError(null, 'Unable to update .clasp.json');

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -122,6 +122,7 @@ Did you provide the correct scriptId?`,
   SETTINGS_DNE: `\nNo ${DOT.PROJECT.PATH} settings found. \`create\` or \`clone\` a project first.`,
   UNAUTHENTICATED_LOCAL: `Error: Local client credentials unauthenticated. Check scopes/authorization.`,
   UNAUTHENTICATED: 'Error: Unauthenticated request: Please try again.',
+  UNKNOWN_KEY: (key: string) => `Unknown key "${key}"`,
 };
 
 // Log messages (some logs take required params)

--- a/tests/test.ts
+++ b/tests/test.ts
@@ -505,7 +505,7 @@ describe('Test setting function', () => {
     );
     const fileContents = fs.readFileSync('.clasp.json', 'utf8');
     expect(result.stdout).to.contain('Updated "scriptId":');
-    expect(result.stdout).to.contain('-> "test"');
+    expect(result.stdout).to.contain('→ "test"');
     expect(fileContents).to.contain('"test"');
   });
   it('should error on unknown keys', () => {
@@ -514,14 +514,14 @@ describe('Test setting function', () => {
       CLASP, ['setting', 'foo'], { encoding: 'utf8' },
     );
     expect(result.status).to.equal(1);
-    expect(result.stderr).to.contain('Unknown key "foo"');
+    expect(result.stderr).to.contain(ERROR.UNKNOWN_KEY('foo'));
 
     // Test setting
     result = spawnSync(
       CLASP, ['setting', 'bar', 'foo'], { encoding: 'utf8' },
     );
     expect(result.status).to.equal(1);
-    expect(result.stderr).to.contain('Setting "bar" is unsupported');
+    expect(result.stderr).to.contain(ERROR.UNKNOWN_KEY('bar'));
   });
   after(cleanup);
 });


### PR DESCRIPTION
Previously, when trying to update unsupported keys, the output would be:

```
🐷  clasp setting bar foo                                                                                           temp : master*
Updated "bar": "" → "foo"
```

Now, it will give the error:

```
Unknown key "bar"
```

Signed-off-by: campionfellin <campionfellin@gmail.com>

- [ ] `npm run test` succeeds.
- [x] `npm run lint` succeeds.
- [ ] Appropriate changes to README are included in PR.
