### PR TITLE
`saveProject` should not read  if project not found

### DIFF
--- a/src/commands.ts
+++ b/src/commands.ts
@@ -242,7 +242,7 @@ export const create = async (cmd: { type: string; title: string; parentId: strin
     saveProject({
       scriptId: createdScriptId,
       rootDir,
-    });
+    }, false);
     if (!manifestExists()) {
       const files = await fetchProject(createdScriptId); // fetches appsscript.json, o.w. `push` breaks
       writeProjectFiles(files, rootDir); // fetches appsscript.json, o.w. `push` breaks
@@ -303,7 +303,7 @@ export const clone = async (scriptId: string, versionNumber?: number) => {
   spinner.setSpinnerTitle(LOG.CLONING);
   saveProject({
     scriptId,
-  });
+  }, false);
   const files = await fetchProject(scriptId, versionNumber);
   await writeProjectFiles(files, '');
 };

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -331,7 +331,7 @@ export async function checkIfOnline() {
 export async function saveProject(
     newProjectSettings: ProjectSettings,
     append = true): Promise<ProjectSettings> {
-  if (append) {
+  if (append && await DOTFILE.PROJECT().exists()) {
     const projectSettings: ProjectSettings = await DOTFILE.PROJECT().read();
     newProjectSettings = {...projectSettings, ...newProjectSettings};
   }

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -331,7 +331,7 @@ export async function checkIfOnline() {
 export async function saveProject(
     newProjectSettings: ProjectSettings,
     append = true): Promise<ProjectSettings> {
-  if (append && await DOTFILE.PROJECT().exists()) {
+  if (append) {
     const projectSettings: ProjectSettings = await DOTFILE.PROJECT().read();
     newProjectSettings = {...projectSettings, ...newProjectSettings};
   }


### PR DESCRIPTION
Fixes #452 

`Clasp clone` call `saveProject` to setup `.clasp.json` with `ScriptId`
Actualy , `saveProject` will read `.clasp.json` to overwrite it.
So, I fix `saveProject` to don't read `.clasp.json` if project not found.

- [x] `npm run test` succeeds.
- [x] `npm run lint` succeeds.
- [x] Appropriate changes to README are included in PR.
