### PR TITLE
Enable Apps Script API when `clasp login --creds creds.json`

### DIFF
--- a/src/apiutils.ts
+++ b/src/apiutils.ts
@@ -1,6 +1,6 @@
 import * as fuzzy from 'fuzzy';
 import { script_v1 } from 'googleapis';
-import { serviceUsage } from './auth';
+import { serviceUsage, loadAPICredentials } from './auth';
 import { enableOrDisableAdvanceServiceInManifest } from './manifest';
 import { ERROR, getProjectId, logError, spinner } from './utils';
 
@@ -93,4 +93,14 @@ export async function enableOrDisableAPI(serviceName: string, enable: boolean) {
     console.log(e);
     logError(null, ERROR.NO_API(enable, serviceName));
   }
+}
+
+/**
+ * Enable 'script.googleapis.com' of Google API.
+ */
+export async function enableAppsScriptAPI(){
+   await loadAPICredentials();
+   const projectId = await getProjectIdWithErrors();
+   const name = `projects/${projectId}/services/script.googleapis.com`;
+   await serviceUsage.services.enable({ name });
 }

--- a/src/commands.ts
+++ b/src/commands.ts
@@ -14,6 +14,7 @@ import { PUBLIC_ADVANCED_SERVICES, SCRIPT_TYPES } from './apis';
 import {
   enableOrDisableAPI,
   getFunctionNames,
+  getProjectIdWithErrors,
 } from './apiutils';
 import {
   authorize,
@@ -357,6 +358,12 @@ export const login = async (options: { localhost?: boolean; creds?: string }) =>
       creds: credentials,
       scopes: oauthScopes,
     });
+
+    // Ebnable script.googleapis.com for clasp.run
+    await loadAPICredentials();
+    const projectId = await getProjectIdWithErrors();
+    const name = `projects/${projectId}/services/script.googleapis.com`;
+    await serviceUsage.services.enable({ name });
   } else {
     // Not using own credentials
     await authorize({

--- a/src/commands.ts
+++ b/src/commands.ts
@@ -14,7 +14,7 @@ import { PUBLIC_ADVANCED_SERVICES, SCRIPT_TYPES } from './apis';
 import {
   enableOrDisableAPI,
   getFunctionNames,
-  getProjectIdWithErrors,
+  enableAppsScriptAPI,
 } from './apiutils';
 import {
   authorize,
@@ -358,12 +358,7 @@ export const login = async (options: { localhost?: boolean; creds?: string }) =>
       creds: credentials,
       scopes: oauthScopes,
     });
-
-    // Ebnable script.googleapis.com for clasp.run
-    await loadAPICredentials();
-    const projectId = await getProjectIdWithErrors();
-    const name = `projects/${projectId}/services/script.googleapis.com`;
-    await serviceUsage.services.enable({ name });
+    await enableAppsScriptAPI();
   } else {
     // Not using own credentials
     await authorize({


### PR DESCRIPTION
Fixes #462 

If you enter the `creds` option at login, the Apps Script API will be enabled.

Currently, the process of enabling api is at the top level of the command function.
Should I implement it in `authorize`?

- [ ] `npm run test` succeeds.
- [x] `npm run lint` succeeds.
- [x] Appropriate changes to README are included in PR.

