### PR TITLE
Fix getScriptTypeName return undefined

### DIFF
--- a/src/utils.ts
+++ b/src/utils.ts
@@ -394,7 +394,7 @@ function getFileTypeName(type: string) {
  */
 function getScriptTypeName(type: string) {
   const fileType = getFileTypeName(type);
-  return fileType ? `${fileType}s Add-on` : fileType;
+  return fileType ? `${fileType}s Add-on` : type;
 }
 
 /**


### PR DESCRIPTION
Fixes #474 

By `getScriptTypeName` returning undefined when script type is not an add-on, the message at project creation was not displayed correctly.

```
$ clasp create
Created new undefined script: https://script.google.com/d/XXXXXX/edit
Cloned 1 file.
└─ appsscript.json
```

I fixed `getScriptTypeName` to return `type` If `type` is not add-on.

ex :

```
$ clasp create
Created new standalone script: https://script.google.com/d/XXXXXX/edit
Cloned 1 file.
└─ appsscript.json
```

- [ ] `npm run test` succeeds.
- [x] `npm run lint` succeeds.
- [ ] Appropriate changes to README are included in PR.
