### PR TITLE
Clone with rootdir

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,7 +81,7 @@ clasp
 - [`clasp login [--no-localhost] [--creds <file>]`](#login)
 - [`clasp logout`](#logout)
 - [`clasp create [--title <title>] [--type <type>] [--rootDir <dir>] [--parentId <id>]`](#create)
-- [`clasp clone <scriptId | scriptURL> [versionNumber]`](#clone)
+- [`clasp clone <scriptId | scriptURL> [versionNumber] [--rootDir <dir>]`](#clone)
 - [`clasp pull [--versionNumber]`](#pull)
 - [`clasp push [--watch] [--force]`](#push)
 - [`clasp status [--json]`](#status)
@@ -167,11 +167,13 @@ Clones the script project from script.google.com.
 
 - `scriptId | scriptURL`: The script ID _or_ script URL to clone.
 - `versionNumber`: The version of the script to clone.
+- `--rootDir <dir>`: Local directory in which clasp will store your project files. If not specified, clasp will default to the current directory.
 
 #### Examples
 
 - `clasp clone "15ImUCpyi1Jsd8yF8Z6wey_7cw793CymWTLxOqwMka3P1CzE5hQun6qiC"`
 - `clasp clone "https://script.google.com/d/15ImUCpyi1Jsd8yF8Z6wey_7cw793CymWTLxOqwMka3P1CzE5hQun6qiC/edit"`
+- `clasp clone "15ImUCpyi1Jsd8yF8Z6wey_7cw793CymWTLxOqwMka3P1CzE5hQun6qiC" --rootDir ./src`
 
 ### Pull
 

--- a/src/commands.ts
+++ b/src/commands.ts
@@ -311,7 +311,7 @@ export const clone = async (scriptId: string, versionNumber: number, cmd: { root
     rootDir,
   }, false);
   const files = await fetchProject(scriptId, versionNumber);
-  await writeProjectFiles(files, '');
+  await writeProjectFiles(files, rootDir);
 };
 
 /**

--- a/src/commands.ts
+++ b/src/commands.ts
@@ -257,8 +257,10 @@ export const create = async (cmd: { type: string; title: string; parentId: strin
  * Prompts the user if no script ID is provided.
  * @param scriptId {string} The Apps Script project ID to fetch.
  * @param versionNumber {string} An optional version to pull the script from.
+ * @param cmd.rootDir {string} Specifies the local directory in which clasp will store your project files.
+ *                    If not specified, clasp will default to the current directory.
  */
-export const clone = async (scriptId: string, versionNumber?: number) => {
+export const clone = async (scriptId: string, versionNumber: number, cmd: { rootDir: string }) => {
   await checkIfOnline();
   if (hasProject()) return logError(null, ERROR.FOLDER_EXISTS);
   if (!scriptId) {
@@ -303,8 +305,10 @@ export const clone = async (scriptId: string, versionNumber?: number) => {
     }
   }
   spinner.setSpinnerTitle(LOG.CLONING);
+  const rootDir = cmd.rootDir;
   saveProject({
     scriptId,
+    rootDir,
   }, false);
   const files = await fetchProject(scriptId, versionNumber);
   await writeProjectFiles(files, '');

--- a/src/index.ts
+++ b/src/index.ts
@@ -116,10 +116,12 @@ commander
  * Fetches a project and saves the script id locally.
  * @param {string?} [scriptId] The script ID to clone.
  * @param {string?} [versionNumber] The version of the script to clone.
+ * @param {string?} [--rootDir] Local root directory that store your project files.
  */
 commander
   .command('clone [scriptId] [versionNumber]')
   .description('Clone a project')
+  .option('--rootDir <rootDir>', 'Local root directory in which clasp will store your project files.')
   .action(handleError(clone));
 
 /**


### PR DESCRIPTION
Fixes #484 

Add `--rootDir` option to `clasp clone` command.

- [ ] `npm run test` succeeds.
- [x] `npm run lint` succeeds.
- [x] Appropriate changes to README are included in PR.
