### PR TITLE
Add `--all` flag to `clasp undeploy`

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,7 +88,7 @@ clasp
 - [`clasp open [scriptId] [--webapp] [--creds]`](#open)
 - [`clasp deployments`](#deployments)
 - [`clasp deploy [--versionNumber <version>] [--description <description>] [--deploymentId <id>]`](#deploy)
-- [`clasp undeploy [deploymentId]`](#undeploy)
+- [`clasp undeploy [deploymentId] [--all]`](#undeploy)
 - [`clasp version [description]`](#version)
 - [`clasp versions`](#versions)
 - [`clasp list`](#list)
@@ -278,11 +278,13 @@ Undeploys a deployment of a script.
 #### Options
 
 - `deploymentId`: An optional deployment ID.
+- `-a` `--all`: Undeploy all deployments.
 
 #### Examples
 
 - `clasp undeploy` (undeploy the last deployment.)
 - `clasp undeploy "123"`
+- `clasp undeploy --all`
 
 ### Version
 

--- a/src/commands.ts
+++ b/src/commands.ts
@@ -788,11 +788,39 @@ export const deploy = async (cmd: { versionNumber: number; description: string; 
  * Removes a deployment from the Apps Script project.
  * @param deploymentId {string} The deployment's ID
  */
-export const undeploy = async (deploymentId: string) => {
+export const undeploy = async (deploymentId: string, cmd: { all: boolean }) => {
   await checkIfOnline();
   await loadAPICredentials();
   const { scriptId } = await getProjectSettings();
   if (!scriptId) return;
+  if (cmd.all){
+    const deploymentsList = await script.projects.deployments.list({
+      scriptId,
+    });
+    if (deploymentsList.status !== 200) {
+      return logError(deploymentsList.statusText);
+    }
+    const deployments = deploymentsList.data.deployments || [];
+    if (!deployments.length) {
+      logError(null, ERROR.SCRIPT_ID_INCORRECT(scriptId));
+    }
+    deployments.shift(); // @HEAD (Read-only deployments) may not be deleted.
+    for(const deployment of deployments){
+      const deploymentId = deployment.deploymentId || '';
+      spinner.setSpinnerTitle(LOG.UNDEPLOYMENT_START(deploymentId)).start();
+      const result = await script.projects.deployments.delete({
+        scriptId,
+        deploymentId,
+      });
+      spinner.stop(true);
+      if (result.status !== 200) {
+        return logError(null, ERROR.READ_ONLY_DELETE);
+      }
+      console.log(LOG.UNDEPLOYMENT_FINISH(deploymentId));
+    }
+    console.log(LOG.UNDEPLOYMENT_ALL_FINISH);
+    return;
+  }
   if (!deploymentId) {
     const deploymentsList = await script.projects.deployments.list({
       scriptId,

--- a/src/index.ts
+++ b/src/index.ts
@@ -215,12 +215,15 @@ commander
  * Undeploys a deployment of a script.
  * @name undeploy
  * @param {string?} [deploymentId] The deployment ID.
+ * @param {boolean?} all Setup StackDriver logs.
  * @example "undeploy" (undeploy the last deployment.)
  * @example "undeploy 123"
+ * @example "undeploy --all"
  */
 commander
   .command('undeploy [deploymentId]')
   .description('Undeploy a deployment of a project')
+  .option('-a, --all', 'Undeploy all deployments')
   .action(handleError(undeploy));
 
 /**

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -182,6 +182,7 @@ export const LOG = {
   STATUS_IGNORE: 'Ignored files:',
   STATUS_PUSH: 'Not ignored files:',
   UNDEPLOYMENT_FINISH: (deploymentId: string) => `Undeployed ${deploymentId}.`,
+  UNDEPLOYMENT_ALL_FINISH: `Undeployed all deployments.`,
   UNDEPLOYMENT_START: (deploymentId: string) => `Undeploying ${deploymentId}...`,
   VERSION_CREATE: 'Creating a new version...',
   VERSION_CREATED: (versionNumber: number) => `Created version ${versionNumber}.`,


### PR DESCRIPTION
Fixes #480 

- [ ] `npm run test` succeeds.
- [x] `npm run lint` succeeds.
- [x] Appropriate changes to README are included in PR.
