### PR TITLE
.claspIgnore matching for windows

### DIFF
--- a/src/files.ts
+++ b/src/files.ts
@@ -108,7 +108,7 @@ export async function getProjectFiles(rootDir: string = path.join('.', '/'), cal
         if (abortPush) return callback(new Error(), null, null);
 
         // Replace OS specific path separator to common '/' char for console output
-        filePaths = filePaths.map( (name) => name.replace(/\\/g, '/') );
+        filePaths = filePaths.map((name) => name.replace(/\\/g, '/'));
 
         // check ignore files
         const ignoreMatches = multimatch(filePaths, ignorePatterns, { dot: true });

--- a/src/files.ts
+++ b/src/files.ts
@@ -108,7 +108,7 @@ export async function getProjectFiles(rootDir: string = path.join('.', '/'), cal
         if (abortPush) return callback(new Error(), null, null);
 
         // Replace OS specific path separator to common '/' char for console output
-        filePaths = filePaths.map( (name) => name.replace(/\\/g, '/') )
+        filePaths = filePaths.map( (name) => name.replace(/\\/g, '/') );
 
         // check ignore files
         const ignoreMatches = multimatch(filePaths, ignorePatterns, { dot: true });
@@ -160,7 +160,6 @@ export async function getProjectFiles(rootDir: string = path.join('.', '/'), cal
               }
               const validType = type && isValidJSONIfJSON;
               const notIgnored = !ignoreMatches.includes(name);
-              console.log(name)
               valid = !!(valid && validType && notIgnored);
               return valid;
             };

--- a/src/files.ts
+++ b/src/files.ts
@@ -107,14 +107,15 @@ export async function getProjectFiles(rootDir: string = path.join('.', '/'), cal
         });
         if (abortPush) return callback(new Error(), null, null);
 
+        // Replace OS specific path separator to common '/' char for console output
+        filePaths = filePaths.map( (name) => name.replace(/\\/g, '/') )
+
         // check ignore files
         const ignoreMatches = multimatch(filePaths, ignorePatterns, { dot: true });
 
         // Loop through every file.
         const files = filePaths
           .map((name, i) => {
-            // Replace OS specific path separator to common '/' char for console output
-            name = name.replace(/\\/g, '/');
             const normalizedName = path.normalize(name);
 
             let type = getAPIFileType(name);
@@ -159,6 +160,7 @@ export async function getProjectFiles(rootDir: string = path.join('.', '/'), cal
               }
               const validType = type && isValidJSONIfJSON;
               const notIgnored = !ignoreMatches.includes(name);
+              console.log(name)
               valid = !!(valid && validType && notIgnored);
               return valid;
             };


### PR DESCRIPTION
Fixes #492 

Replace OS specific path separator before `multimatch`.

- [ ] `npm run test` succeeds.
- [x] `npm run lint` succeeds.
- [ ] Appropriate changes to README are included in PR.



