### PR TITLE
Use inlineSourceMaps for better test coverage checks

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -9,6 +9,7 @@
       "es2017"
     ],
     "strict": true,
+    "inlineSourceMap": true,
   },
   "moduleResolution": "node",
   "files": [


### PR DESCRIPTION
General testing improvement... we can now see more accurate coverage numbers and missing lines. 

#### Previously:

<img width="636" alt="screen shot 2019-01-31 at 7 25 43 pm" src="https://user-images.githubusercontent.com/11984923/52102198-189f6e80-2594-11e9-8dd8-80bbbd408066.png">

#### Now

<img width="606" alt="screen shot 2019-01-31 at 7 23 55 pm" src="https://user-images.githubusercontent.com/11984923/52102206-1ccb8c00-2594-11e9-84bf-45532a2359f0.png">


(note this is just one test). We can see now it covers the `.ts` files instead of `.js` files.

Signed-off-by: campionfellin <campionfellin@gmail.com>

- [x] `npm run test` succeeds.
- [x] `npm run lint` succeeds.
- [ ] Appropriate changes to README are included in PR.
