### PR TITLE
Refactor clasp logout

### DIFF
--- a/src/commands.ts
+++ b/src/commands.ts
@@ -4,7 +4,6 @@ import { readFileSync } from 'fs';
  */
 import chalk from 'chalk';
 import * as commander from 'commander';
-import * as del from 'del';
 import * as pluralize from 'pluralize';
 import { PUBLIC_ADVANCED_SERVICES, SCRIPT_TYPES } from './apis';
 import {
@@ -22,7 +21,7 @@ import {
   script,
   serviceUsage,
 } from './auth';
-import { DOT, DOTFILE, ProjectSettings } from './dotfile';
+import { DOTFILE, ProjectSettings } from './dotfile';
 import { fetchProject, getProjectFiles, hasProject, pushFiles, writeProjectFiles } from './files';
 import {
   addScopeToManifest,
@@ -234,15 +233,6 @@ export const login = async (options: { localhost?: boolean; creds?: string }) =>
     });
   }
   process.exit(0); // gracefully exit after successful login
-};
-
-/**
- * Logs out the user by deleting credentials.
- */
-export const logout = async () => {
-  if (hasOauthClientSettings(true)) del(DOT.RC.ABSOLUTE_LOCAL_PATH, { force: true });
-  // del doesn't work with a relative path (~)
-  if (hasOauthClientSettings()) del(DOT.RC.ABSOLUTE_PATH, { force: true });
 };
 
 /**

--- a/src/commands/logout.ts
+++ b/src/commands/logout.ts
@@ -1,0 +1,12 @@
+import { DOT } from './../dotfile';
+import { hasOauthClientSettings } from './../utils';
+import * as del from 'del';
+
+/**
+ * Logs out the user by deleting credentials.
+ */
+export default async () => {
+  if (hasOauthClientSettings(true)) del(DOT.RC.ABSOLUTE_LOCAL_PATH, { force: true });
+  // del doesn't work with a relative path (~)
+  if (hasOauthClientSettings()) del(DOT.RC.ABSOLUTE_PATH, { force: true });
+};

--- a/src/index.ts
+++ b/src/index.ts
@@ -32,7 +32,6 @@ import {
   help,
   list,
   login,
-  logout,
   logs,
   openCmd,
   run,
@@ -47,6 +46,7 @@ import { PROJECT_NAME, handleError } from './utils';
 import pull from './commands/pull';
 import clone from './commands/clone';
 import push from './commands/push';
+import logout from './commands/logout';
 
 // const commander = require('commander');
 


### PR DESCRIPTION
Signed-off-by: campionfellin <campionfellin@gmail.com>

Fixes #501

- [x] `npm run test` succeeds.
- [x] `npm run lint` succeeds.
- [ ] Appropriate changes to README are included in PR.
