### PR TITLE
Refactor clasp status

### DIFF
--- a/src/commands.ts
+++ b/src/commands.ts
@@ -23,7 +23,7 @@ import {
   serviceUsage,
 } from './auth';
 import { DOT, DOTFILE, ProjectSettings } from './dotfile';
-import { fetchProject, getProjectFiles, hasProject, pushFiles, writeProjectFiles } from './files';
+import { fetchProject, hasProject, pushFiles, writeProjectFiles } from './files';
 import {
   addScopeToManifest,
   isValidManifest,
@@ -814,32 +814,6 @@ export const version = async (description: string) => {
     return logError(versions.statusText);
   }
   console.log(LOG.VERSION_CREATED(versions.data.versionNumber || -1));
-};
-
-/**
- * Displays the status of which Apps Script files are ignored from .claspignore
- * @param cmd.json {boolean} Displays the status in json format.
- */
-export const status = async (cmd: { json: boolean }) => {
-  await checkIfOnline();
-  await isValidManifest();
-  const { scriptId, rootDir } = await getProjectSettings();
-  if (!scriptId) return;
-  getProjectFiles(rootDir, (err, projectFiles) => {
-    if (err) return console.log(err);
-    if (projectFiles) {
-      const [filesToPush, untrackedFiles] = projectFiles;
-      if (cmd.json) {
-        console.log(JSON.stringify({ filesToPush, untrackedFiles }));
-      } else {
-        console.log(LOG.STATUS_PUSH);
-        filesToPush.forEach(file => console.log(`└─ ${file}`));
-        console.log(); // Separate Ignored files list.
-        console.log(LOG.STATUS_IGNORE);
-        untrackedFiles.forEach(file => console.log(`└─ ${file}`));
-      }
-    }
-  });
 };
 
 /**

--- a/src/commands/status.ts
+++ b/src/commands/status.ts
@@ -1,0 +1,34 @@
+import { getProjectFiles } from './../files';
+import { isValidManifest } from './../manifest';
+
+import {
+  checkIfOnline,
+  getProjectSettings,
+  LOG,
+} from './../utils';
+
+/**
+ * Displays the status of which Apps Script files are ignored from .claspignore
+ * @param cmd.json {boolean} Displays the status in json format.
+ */
+export default async (cmd: { json: boolean }) => {
+  await checkIfOnline();
+  await isValidManifest();
+  const { scriptId, rootDir } = await getProjectSettings();
+  if (!scriptId) return;
+  getProjectFiles(rootDir, (err, projectFiles) => {
+    if (err) return console.log(err);
+    if (projectFiles) {
+      const [filesToPush, untrackedFiles] = projectFiles;
+      if (cmd.json) {
+        console.log(JSON.stringify({ filesToPush, untrackedFiles }));
+      } else {
+        console.log(LOG.STATUS_PUSH);
+        filesToPush.forEach(file => console.log(`└─ ${file}`));
+        console.log(); // Separate Ignored files list.
+        console.log(LOG.STATUS_IGNORE);
+        untrackedFiles.forEach(file => console.log(`└─ ${file}`));
+      }
+    }
+  });
+};

--- a/src/index.ts
+++ b/src/index.ts
@@ -37,7 +37,6 @@ import {
   openCmd,
   run,
   setting,
-  status,
   undeploy,
   version,
   versions,
@@ -47,6 +46,7 @@ import { PROJECT_NAME, handleError } from './utils';
 import pull from './commands/pull';
 import clone from './commands/clone';
 import push from './commands/push';
+import status from './commands/status';
 
 // const commander = require('commander');
 


### PR DESCRIPTION
No logic changes, just moving code out to separate file.

Signed-off-by: campionfellin <campionfellin@gmail.com>

Fixes #501

- [x] `npm run test` succeeds.
- [x] `npm run lint` succeeds.
- [ ] Appropriate changes to README are included in PR.
