### PR TITLE
Improve consistency of information on 'clasp run'

### DIFF
--- a/README.md
+++ b/README.md
@@ -346,10 +346,12 @@ INFO  Sat Apr 07 2019 10:58:31 GMT-0700 (PDT) myFunction      info message
 
 Remotely executes an Apps Script function.
 
-To use this command you must:
-1. Log in with your credentials (`clasp login --creds creds.json`)
+The complete step-by-step information on how to use `clasp run` is available here: [Run](/docs/run.md)  
+Below is a short summary:
+
+1. Log in with your credentials (`clasp login --creds creds.json`), see: [Run - Prerequisites](/docs/run.md#prerequisites)
 1. Deploy the Script as an API executable (Easiest done via GUI at the moment).
-1. Enable any APIs that are used by the script.
+1. Enable any APIs that are used by the script, see: [Run - Function with Scopes](/docs/run.md#run-a-function-that-requires-scopes)
 1. Have the following in your `appsscript.json`:
 
 ```json

--- a/docs/run.md
+++ b/docs/run.md
@@ -15,7 +15,6 @@ To use `clasp run`, you need to complete 4 steps:
     "access": "ANYONE"
   }
   ```
-- _(Optional) Setup Scopes_
 
 #### Setup Instructions
 

--- a/docs/run.md
+++ b/docs/run.md
@@ -4,11 +4,18 @@
 
 ### Prerequisites
 
-To use `clasp run`, you need to complete 3 steps:
+To use `clasp run`, you need to complete 4 steps:
 
 - Set up a **Project ID**.
 - Create an **OAuth Client ID** (Other). Download as `creds.json`.
 - `clasp login --creds creds.json` with this downloaded file.
+- Add the following to `appsscript.json`:
+  ```json
+  "executionApi": {
+    "access": "ANYONE"
+  }
+  ```
+- _(Optional) Setup Scopes_
 
 #### Setup Instructions
 


### PR DESCRIPTION
Improves on #391

I couldn't figure out how to use `clasp run`, even after following all the steps in [/docs/run.md](https://github.com/google/clasp/blob/master/docs/run.md). After some research, I ended up on Issue [#391](https://github.com/google/clasp/issues/391#issuecomment-449383171). 

It turns out the information was already available on the [README.md - Run](https://github.com/google/clasp#run) but wasn't replicated in [/docs/run.md](https://github.com/google/clasp/blob/master/docs/run.md)

I tried to make the process easier to follow by improving the consistency of information across both sources.