### PR TITLE
Refactor default and help commands

### DIFF
--- a/src/commands.ts
+++ b/src/commands.ts
@@ -3,7 +3,6 @@ import { readFileSync } from 'fs';
  * Clasp command method bodies.
  */
 import chalk from 'chalk';
-import * as commander from 'commander';
 import * as pluralize from 'pluralize';
 import { PUBLIC_ADVANCED_SERVICES, SCRIPT_TYPES } from './apis';
 import {
@@ -53,22 +52,6 @@ const padEnd = require('string.prototype.padend');
 // setup inquirer
 const prompt = inquirer.prompt;
 inquirer.registerPrompt('autocomplete', require('inquirer-autocomplete-prompt'));
-
-/**
- * Outputs the help command.
- */
-export const help = async () => {
-  commander.outputHelp();
-  process.exit(0);
-};
-
-/**
- * Displays a default message when an unknown command is typed.
- * @param command {string} The command that was typed.
- */
-export const defaultCmd = async (command: string) => {
-  logError(null, ERROR.COMMAND_DNE(command));
-};
 
 /**
  * Creates a new Apps Script project.

--- a/src/commands/defaultCmd.ts
+++ b/src/commands/defaultCmd.ts
@@ -1,0 +1,12 @@
+import {
+  ERROR,
+  logError,
+} from './../utils';
+
+/**
+ * Displays a default message when an unknown command is typed.
+ * @param command {string} The command that was typed.
+ */
+export default async (command: string) => {
+  logError(null, ERROR.COMMAND_DNE(command));
+};

--- a/src/commands/help.ts
+++ b/src/commands/help.ts
@@ -1,0 +1,9 @@
+import * as commander from 'commander';
+
+/**
+ * Outputs the help command.
+ */
+export default async () => {
+  commander.outputHelp();
+  process.exit(0);
+};

--- a/src/index.ts
+++ b/src/index.ts
@@ -26,10 +26,8 @@ import * as commander from 'commander';
 import {
   apis,
   create,
-  defaultCmd,
   deploy,
   deployments,
-  help,
   login,
   logs,
   openCmd,
@@ -47,6 +45,8 @@ import status from './commands/status';
 import list from './commands/list';
 import logout from './commands/logout';
 import versions from './commands/versions';
+import defaultCmd from './commands/defaultCmd';
+import help from './commands/help';
 
 // const commander = require('commander');
 


### PR DESCRIPTION
Signed-off-by: campionfellin <campionfellin@gmail.com>

Fixes #501

- [x] `npm run test` succeeds.
- [x] `npm run lint` succeeds.
- [ ] Appropriate changes to README are included in PR.
