### PR TITLE
Refactor clasp logout test

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "build-fresh": "npm cache clean --force && npm i && npm run build",
     "publish": "npm publish --access public",
     "lint": "tslint --project tslint.json && echo 'No lint errors. All good!'",
-    "test": "nyc --cache false mocha --timeout 100000 -- tests/*.js",
+    "test": "nyc --cache false mocha --timeout 100000 -- 'tests/**/*.js'",
     "coverage": "nyc --cache false report --reporter=text-lcov | coveralls",
     "prettier": "./node_modules/prettier/bin-prettier.js --parser typescript --single-quote --bracket-spacing --print-width 110 --trailing-comma all src/**/*.ts --write"
   },

--- a/tests/commands/logout.ts
+++ b/tests/commands/logout.ts
@@ -7,18 +7,18 @@ import {
   CLASP,
   CLASP_PATHS,
   FAKE_CLASPRC,
-} from './../constants';
+} from '../constants';
 
 import {
   backupSettings,
   cleanup,
   restoreSettings,
   setup,
-} from './../functions';
+} from '../functions';
 
 import {
   hasOauthClientSettings,
-} from './../../src/utils';
+} from '../../src/utils';
 
 describe('Test clasp logout function', () => {
   before(setup);

--- a/tests/commands/logout.ts
+++ b/tests/commands/logout.ts
@@ -1,0 +1,52 @@
+import { expect } from 'chai';
+import * as fs from 'fs-extra';
+import { describe, it } from 'mocha';
+const { spawnSync } = require('child_process');
+
+import {
+  CLASP,
+  CLASP_PATHS,
+  FAKE_CLASPRC,
+} from './../constants';
+
+import {
+  backupSettings,
+  cleanup,
+  restoreSettings,
+  setup,
+} from './../functions';
+
+import {
+  hasOauthClientSettings,
+} from './../../src/utils';
+
+describe('Test clasp logout function', () => {
+  before(setup);
+  beforeEach(backupSettings);
+  it('should remove global AND local credentails', () => {
+    fs.writeFileSync(CLASP_PATHS.rcGlobal, FAKE_CLASPRC.token);
+    fs.writeFileSync(CLASP_PATHS.rcLocal, FAKE_CLASPRC.local);
+    const result = spawnSync(
+      CLASP, ['logout'], { encoding: 'utf8' },
+    );
+    expect(fs.existsSync(CLASP_PATHS.rcGlobal)).to.equal(false);
+    expect(hasOauthClientSettings()).to.equal(false);
+    expect(fs.existsSync(CLASP_PATHS.rcLocal)).to.equal(false);
+    expect(hasOauthClientSettings(true)).to.equal(false);
+    expect(result.status).to.equal(0);
+  });
+  it('should still work with no clasprc file', () => {
+    const result = spawnSync(
+      CLASP, ['logout'], { encoding: 'utf8' },
+    );
+    expect(fs.existsSync(CLASP_PATHS.rcGlobal)).to.equal(false);
+    expect(hasOauthClientSettings()).to.equal(false);
+    expect(fs.existsSync(CLASP_PATHS.rcLocal)).to.equal(false);
+    expect(hasOauthClientSettings(true)).to.equal(false);
+    expect(result.status).to.equal(0);
+  });
+  after(() => {
+    restoreSettings();
+    cleanup();
+  });
+});

--- a/tests/test.ts
+++ b/tests/test.ts
@@ -10,7 +10,6 @@ import {
   getAPIFileType,
   getDefaultProjectName,
   getWebApplicationURL,
-  hasOauthClientSettings,
   saveProject,
 } from './../src/utils';
 
@@ -727,30 +726,6 @@ describe('Test clasp login function', () => {
     fs.removeSync(CLASP_PATHS.clientCredsLocal);
     expect(result.stdout).to.contain(LOG.LOGIN(true));
     expect(result.status).to.equal(1);
-  });
-  after(cleanup);
-});
-
-describe('Test clasp logout function', () => {
-  before(function () {
-    if (IS_PR) {
-      this.skip();
-    }
-    setup();
-  });
-  beforeEach(backupSettings);
-  afterEach(restoreSettings);
-  it('should remove global AND local credentails', () => {
-    fs.writeFileSync(CLASP_PATHS.rcGlobal, FAKE_CLASPRC.token);
-    fs.writeFileSync(CLASP_PATHS.rcLocal, FAKE_CLASPRC.local);
-    const result = spawnSync(
-      CLASP, ['logout'], { encoding: 'utf8' },
-    );
-    expect(fs.existsSync(CLASP_PATHS.rcGlobal)).to.equal(false);
-    expect(hasOauthClientSettings()).to.equal(false);
-    expect(fs.existsSync(CLASP_PATHS.rcLocal)).to.equal(false);
-    expect(hasOauthClientSettings(true)).to.equal(false);
-    expect(result.status).to.equal(0);
   });
   after(cleanup);
 });

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -12,9 +12,8 @@
     "inlineSourceMap": true,
   },
   "moduleResolution": "node",
-  "files": [
-    "src/index.ts",
-    "tests/test.ts",
-    "tests/commands/logout.ts"
+  "include": [
+    "src/**/*.ts",
+    "tests/**/*.ts"
   ]
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -14,6 +14,7 @@
   "moduleResolution": "node",
   "files": [
     "src/index.ts",
-    "tests/test.ts"
+    "tests/test.ts",
+    "tests/commands/logout.ts"
   ]
 }


### PR DESCRIPTION
This puts `clasp logout` test in its own file. Similar to the `src/` refactoring effort.

Additionally, `clasp logout` now has 100% branch coverage (including the implicit `else {}` here:

https://github.com/google/clasp/blob/d889f0edac98af3d280aa37162da0e9ac1486da9/src/commands/logout.ts#L9-L11

Note: Travis tests are failing for `clasp deploy` and `clasp version` due to API quota limits (probably just have to wait ~24 hours)

Signed-off-by: campionfellin <campionfellin@gmail.com>

- [ ] `npm run test` succeeds.
- [x] `npm run lint` succeeds.
- [ ] Appropriate changes to README are included in PR.
