### PR TITLE
Refactor and add more clasp open tests

### DIFF
--- a/tests/commands/open.ts
+++ b/tests/commands/open.ts
@@ -1,0 +1,50 @@
+import { expect } from 'chai';
+import { describe, it } from 'mocha';
+const { spawnSync } = require('child_process');
+
+import {
+  CLASP,
+  PROJECT_ID,
+  SCRIPT_ID,
+} from '../constants';
+
+import {
+  cleanup,
+  setup,
+} from '../functions';
+
+import { URL } from '../../src/urls';
+import {
+  ERROR,
+  LOG,
+} from '../../src/utils';
+
+describe('Test clasp open function', () => {
+  before(setup);
+  it('should open script correctly', () => {
+    const result = spawnSync(
+      CLASP, ['open'], { encoding: 'utf8' },
+    );
+    expect(result.stdout).to.contain(`Opening script: ${URL.SCRIPT(SCRIPT_ID)}`);
+  });
+  it('should error with incorrect scriptId if length < 30', () => {
+    const result = spawnSync(
+      CLASP, ['open', 'abc123'], { encoding: 'utf8' },
+    );
+    expect(result.stderr).to.contain(ERROR.SCRIPT_ID_INCORRECT('abc123'));
+    expect(result.status).to.equal(1);
+  });
+  it('open credentials page correctly', () => {
+    const result = spawnSync(
+      CLASP, ['open', '--creds'], { encoding: 'utf8' },
+    );
+    expect(result.stdout).to.contain(LOG.OPEN_CREDS(PROJECT_ID));
+  });
+  it('open credentials page correctly', () => {
+    const result = spawnSync(
+      CLASP, ['open', '--webapp'], { encoding: 'utf8' },
+    );
+    expect(result.stdout).to.contain('Open which deployment?');
+  });
+  after(cleanup);
+});

--- a/tests/constants.ts
+++ b/tests/constants.ts
@@ -18,7 +18,7 @@ export const TEST_APPSSCRIPT_JSON = JSON.stringify({
 // Travis Env Variables
 export const IS_PR: boolean = (process.env.TRAVIS_PULL_REQUEST === 'true');
 export const SCRIPT_ID: string = process.env.SCRIPT_ID || '';
-const PROJECT_ID: string = process.env.PROJECT_ID || '';
+export const PROJECT_ID: string = process.env.PROJECT_ID || '';
 const HOME: string = process.env.HOME || '';
 
 // Paths

--- a/tests/test.ts
+++ b/tests/test.ts
@@ -185,22 +185,6 @@ describe('Test clasp pull function', () => {
   after(cleanup);
 });
 
-describe('Test clasp open function', () => {
-  before(function () {
-    if (IS_PR) {
-      this.skip();
-    }
-    setup();
-  });
-  it('should prompt for which deployment to open correctly', () => {
-    const result = spawnSync(
-      CLASP, ['open'], { encoding: 'utf8' },
-    );
-    expect(result.stdout).to.contain(`Opening script: ${URL.SCRIPT(SCRIPT_ID)}`);
-  });
-  after(cleanup);
-});
-
 describe('Test URL utils function', () => {
   it('should create Script URL correctly', () => {
     const expectedUrl = `https://script.google.com/d/${SCRIPT_ID}/edit`;


### PR DESCRIPTION
Adds more tests to `clasp open`, resulting in higher coverage.

From:
```
File             |  % Stmts | % Branch |  % Funcs |  % Lines | Uncovered Line #s |
openCmd.ts     |    40.74 |    15.38 |    33.33 |    40.43 |... 83,90,96,97,98 |
```

To:

```
File             |  % Stmts | % Branch |  % Funcs |  % Lines | Uncovered Line #s |
 openCmd.ts     |    83.33 |    76.92 |      100 |    85.11 |... 67,73,96,97,98 |
```
Signed-off-by: campionfellin <campionfellin@gmail.com>

- [x] `npm run test` succeeds.
- [x] `npm run lint` succeeds.
- [ ] Appropriate changes to README are included in PR.
