### PR TITLE
Refactor and rewrite clasp run and manifest tests

### DIFF
--- a/src/commands/run.ts
+++ b/src/commands/run.ts
@@ -10,13 +10,14 @@ import {
 } from '../auth';
 import {
   addScopeToManifest,
-  isValidManifest,
+  isValidRunManifest,
 } from '../manifest';
 import { URL } from '../urls';
 import {
   ERROR,
   checkIfOnline,
   getProjectSettings,
+  getValidJSON,
   logError,
   spinner,
 } from '../utils';
@@ -24,32 +25,20 @@ import {
  * Executes an Apps Script function. Requires clasp login --creds.
  * @param functionName {string} The function name within the Apps Script project.
  * @param cmd.nondev {boolean} If we want to run the last deployed version vs the latest code.
+ * @param cmd.params {string} JSON string of parameters to be input to function.
  * @see https://developers.google.com/apps-script/api/how-tos/execute
  * @requires `clasp login --creds` to be run beforehand.
  */
 export default async (functionName: string, cmd: { nondev: boolean; params: string }) => {
-  function IsValidJSONString(str: string) {
-    try {
-      JSON.parse(str);
-    } catch (error) {
-      throw new Error('Error: Input params not Valid JSON string. Please fix and try again');
-    }
-    return true;
-  }
 
   await checkIfOnline();
   await loadAPICredentials();
   const { scriptId } = await getProjectSettings(true);
   const devMode = !cmd.nondev; // defaults to true
   const { params: paramString = '[]' } = cmd;
-  IsValidJSONString(paramString);
-  const params = JSON.parse(paramString);
-  // Ensures the manifest is correct for running a function.
-  // The manifest must include:
-  // "executionApi": {
-  //   "access": "MYSELF"
-  // }
-  await isValidManifest();
+  const params = getValidJSON(paramString);
+
+  await isValidRunManifest();
 
   // TODO COMMENT THIS. This uses a method that gives a HTML 404.
   // await enableExecutionAPI();
@@ -59,6 +48,7 @@ export default async (functionName: string, cmd: { nondev: boolean; params: stri
   // - Ensure the execution API is enabled.
   // - Ensure we can run functions that were developed locally but not pushed.
   if (devMode) {
+    console.log('Running in dev mode.');
     // TODO enable this once we can properly await pushFiles
     // await pushFiles(true);
   }
@@ -66,106 +56,107 @@ export default async (functionName: string, cmd: { nondev: boolean; params: stri
   // Get the list of functions.
   if (!functionName) functionName = await getFunctionNames(script, scriptId);
 
-  /**
-   * Runs a function.
-   * @see https://developers.google.com/apps-script/api/reference/rest/v1/scripts/run#response-body
-   */
-  async function runFunction(functionName: string, params: string[]) {
-    try {
-      // Load local credentials.
-      await loadAPICredentials(true);
-      const localScript = await getLocalScript();
-      spinner.setSpinnerTitle(`Running function: ${functionName}`).start();
-      const res = await localScript.scripts.run({
-        scriptId,
-        requestBody: {
-          function: functionName,
-          parameters: params,
-          devMode,
-        },
-      });
-      spinner.stop(true);
-      if (!res || !res.data.done) {
-        logError(null, ERROR.RUN_NODATA);
-        process.exit(0); // exit gracefully in case localhost server spun up for authorize
+  await runFunction(functionName, params, scriptId, devMode);
+};
+
+/**
+ * Runs a function.
+ * @see https://developers.google.com/apps-script/api/reference/rest/v1/scripts/run#response-body
+ */
+async function runFunction(functionName: string, params: string[], scriptId: string, devMode: boolean) {
+  try {
+    // Load local credentials.
+    await loadAPICredentials(true);
+    const localScript = await getLocalScript();
+    spinner.setSpinnerTitle(`Running function: ${functionName}`).start();
+    const res = await localScript.scripts.run({
+      scriptId,
+      requestBody: {
+        function: functionName,
+        parameters: params,
+        devMode,
+      },
+    });
+    spinner.stop(true);
+    if (!res || !res.data.done) {
+      logError(null, ERROR.RUN_NODATA);
+      process.exit(0); // exit gracefully in case localhost server spun up for authorize
+    }
+    const data = res.data;
+    // @see https://developers.google.com/apps-script/api/reference/rest/v1/scripts/run#response-body
+    if (data.response) {
+      if (data.response.result) {
+        console.log(data.response.result);
+      } else {
+        console.log(chalk.red('No response.'));
       }
-      const data = res.data;
-      // @see https://developers.google.com/apps-script/api/reference/rest/v1/scripts/run#response-body
-      if (data.response) {
-        if (data.response.result) {
-          console.log(data.response.result);
-        } else {
-          console.log(chalk.red('No response.'));
-        }
-      } else if (data.error && data.error.details) {
-        // @see https://developers.google.com/apps-script/api/reference/rest/v1/scripts/run#Status
-        console.error(
-          `${chalk.red('Exception:')}`,
-          data.error.details[0].errorType,
-          data.error.details[0].errorMessage,
-          data.error.details[0].scriptStackTraceElements || [],
-        );
-      }
-    } catch (err) {
-      spinner.stop(true);
-      if (err) {
-        // TODO move these to logError when stable?
-        switch (err.code) {
-          case 401:
-            // The 401 is probably due to this error:
-            // "Error: Local client credentials unauthenticated. Check scopes/authorization.""
-            // This is probably due to the OAuth client not having authorized scopes.
-            console.log(`` +
-              `Hey! It looks like you aren't authenticated for the scopes required by this script.
+    } else if (data.error && data.error.details) {
+      // @see https://developers.google.com/apps-script/api/reference/rest/v1/scripts/run#Status
+      console.error(
+        `${chalk.red('Exception:')}`,
+        data.error.details[0].errorType,
+        data.error.details[0].errorMessage,
+        data.error.details[0].scriptStackTraceElements || [],
+      );
+    }
+  } catch (err) {
+    spinner.stop(true);
+    if (err) {
+      // TODO move these to logError when stable?
+      switch (err.code) {
+        case 401:
+          // The 401 is probably due to this error:
+          // "Error: Local client credentials unauthenticated. Check scopes/authorization.""
+          // This is probably due to the OAuth client not having authorized scopes.
+          console.log(`` +
+            `Hey! It looks like you aren't authenticated for the scopes required by this script.
 Please enter the scopes by doing the following:
 1. Open Your Script: ${URL.SCRIPT(scriptId)}
 2. File > Project Properties > Scopes
 3. Copy/Paste the list of scopes here:
-              ~ Example ~
+            ~ Example ~
 https://mail.google.com/
 https://www.googleapis.com/auth/presentations
 ----(When you're done, press <Enter> 2x)----`);
-            // Example scopes:
-            // https://mail.google.com/
-            // https://www.googleapis.com/auth/presentations
-            // https://www.googleapis.com/auth/spreadsheets
-            const readline = require('readline');
-            const scopes: string[] = [];
-            const rl = readline.createInterface({
-              input: process.stdin,
-              output: process.stdout,
-              prompt: '',
-            });
-            rl.prompt();
-            rl.on('line', (cmd: string) => {
-              if (cmd === '') {
-                rl.close();
-              } else {
-                scopes.push(cmd);
-              }
-            });
-            rl.on('close', async () => {
-              await addScopeToManifest(scopes);
-              const numScopes = scopes.length;
-              console.log(`Added ${numScopes} ` +
-                `${pluralize('scope', numScopes)} to your appsscript.json' oauthScopes`);
-              console.log('Please `clasp login --creds <file>` to log in with these new scopes.');
-            });
-            // We probably don't need to show the unauth error
-            // since we always prompt the user to fix this now.
-            // logError(null, ERROR.UNAUTHENTICATED_LOCAL);
-            break;
-          case 403:
-            logError(null, ERROR.PERMISSION_DENIED_LOCAL);
-            break;
-          case 404:
-            logError(null, ERROR.EXECUTE_ENTITY_NOT_FOUND);
-            break;
-          default:
-            logError(null, `(${err.code}) Error: ${err.message}`);
-        }
+          // Example scopes:
+          // https://mail.google.com/
+          // https://www.googleapis.com/auth/presentations
+          // https://www.googleapis.com/auth/spreadsheets
+          const readline = require('readline');
+          const scopes: string[] = [];
+          const rl = readline.createInterface({
+            input: process.stdin,
+            output: process.stdout,
+            prompt: '',
+          });
+          rl.prompt();
+          rl.on('line', (cmd: string) => {
+            if (cmd === '') {
+              rl.close();
+            } else {
+              scopes.push(cmd);
+            }
+          });
+          rl.on('close', async () => {
+            await addScopeToManifest(scopes);
+            const numScopes = scopes.length;
+            console.log(`Added ${numScopes} ` +
+              `${pluralize('scope', numScopes)} to your appsscript.json' oauthScopes`);
+            console.log('Please `clasp login --creds <file>` to log in with these new scopes.');
+          });
+          // We probably don't need to show the unauth error
+          // since we always prompt the user to fix this now.
+          // logError(null, ERROR.UNAUTHENTICATED_LOCAL);
+          break;
+        case 403:
+          logError(null, ERROR.PERMISSION_DENIED_LOCAL);
+          break;
+        case 404:
+          logError(null, ERROR.EXECUTE_ENTITY_NOT_FOUND);
+          break;
+        default:
+          logError(null, `(${err.code}) Error: ${err.message}`);
       }
     }
   }
-  await runFunction(functionName, params);
-};
+}

--- a/src/manifest.ts
+++ b/src/manifest.ts
@@ -60,9 +60,9 @@ export async function isValidManifest(): Promise<boolean> {
  * }
  */
 export async function isValidRunManifest(): Promise<boolean> {
-  if (isValidManifest) {
+  if (await isValidManifest()) {
     const manifest = await getManifest();
-    if (manifest.executionApi && manifest.executionApi.access === 'MYSELF') {
+    if (manifest.executionApi && manifest.executionApi.access) {
       return true;
     }
   }

--- a/src/manifest.ts
+++ b/src/manifest.ts
@@ -4,6 +4,7 @@ import { PUBLIC_ADVANCED_SERVICES } from './apis';
 import { enableOrDisableAPI, isEnabled } from './apiutils';
 import { DOT } from './dotfile';
 import { ERROR, PROJECT_MANIFEST_FILENAME, getProjectSettings, logError } from './utils';
+import { getValidJSON } from './utils';
 
 /**
  * Checks if the rootDir appears to be a valid project.
@@ -46,22 +47,40 @@ export async function writeManifest(manifest: Manifest) {
 
 /**
  * Returns true if the manifest is valid.
+ */
+export async function isValidManifest(): Promise<boolean> {
+  return await getManifest() != null;
+}
+
+/**
+ * Ensures the manifest is correct for running a function.
+ * The manifest must include:
+ * "executionApi": {
+ *   "access": "MYSELF"
+ * }
+ */
+export async function isValidRunManifest(): Promise<boolean> {
+  if (isValidManifest) {
+    const manifest = await getManifest();
+    if (manifest.executionApi && manifest.executionApi.access === 'MYSELF') {
+      return true;
+    }
+  }
+  return false;
+}
+
+/**
+ * Reads manifest file from project root dir.
  * The manifest is valid if it:
  * - It exists in the project root.
  * - Is valid JSON.
  */
-export async function isValidManifest(): Promise<boolean> {
+// tslint:disable-next-line:no-any
+export async function getManifest(): Promise<any> {
   let { rootDir } = await getProjectSettings();
   if (typeof rootDir === 'undefined') rootDir = DOT.PROJECT.DIR;
-  const manifest = fs.readFileSync(path.join(rootDir, PROJECT_MANIFEST_FILENAME), 'utf8');
-  let manifestJSON: Manifest;
-  try {
-    manifestJSON = JSON.parse(manifest);
-  } catch (err) {
-    logError(err, ERROR.BAD_MANIFEST);
-    return false;
-  }
-  return true;
+  const manifestString =  fs.readFileSync(path.join(rootDir, PROJECT_MANIFEST_FILENAME), 'utf8');
+  return getValidJSON(manifestString);
 }
 
 /**

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -78,6 +78,7 @@ Forgot ${PROJECT_NAME} commands? Get help:\n  ${PROJECT_NAME} --help`,
   FOLDER_EXISTS: `Project file (${DOT.PROJECT.PATH}) already exists.`,
   FS_DIR_WRITE: 'Could not create directory.',
   FS_FILE_WRITE: 'Could not write file.',
+  INVALID_JSON: `Input params not Valid JSON string. Please fix and try again`,
   LOGGED_IN_LOCAL: `Warning: You seem to already be logged in *locally*. You have a ./.clasprc.json`,
   LOGGED_IN_GLOBAL: `Warning: You seem to already be logged in *globally*. You have a ~/.clasprc.json`,
   LOGGED_OUT: `\nCommand failed. Please login. (${PROJECT_NAME} login)`,
@@ -416,4 +417,16 @@ export function handleError(command: (...args: any[]) => Promise<void>) {
  */
 export function isValidProjectId(projectId: string) {
   return new RegExp(/^[a-z][a-z0-9\-]{5,29}$/).test(projectId);
+}
+
+/**
+ * Gets valid JSON obj or throws error.
+ * @param str JSON string.
+ */
+export function getValidJSON(str: string): string[] {
+  try {
+    return JSON.parse(str);
+  } catch (error) {
+    throw new Error(ERROR.INVALID_JSON);
+  }
 }

--- a/tests/commands/run.ts
+++ b/tests/commands/run.ts
@@ -1,0 +1,64 @@
+import { expect } from 'chai';
+import * as fs from 'fs-extra';
+import { describe, it } from 'mocha';
+const { spawnSync } = require('child_process');
+
+import {
+  CLASP,
+  CLASP_PATHS,
+  CLASP_SETTINGS,
+} from '../constants';
+
+import {
+  cleanup,
+  setup,
+} from '../functions';
+
+import { LOG } from '../../src/utils';
+
+describe('Test clasp run function', () => {
+  before(setup);
+  it('should properly run in dev mode', () => {
+    const result = spawnSync(
+      CLASP, ['run'], { encoding: 'utf8' },
+    );
+    expect(result.stdout).to.include('Running in dev mode.');
+  });
+  it('should not run in dev mode', () => {
+    const result = spawnSync(
+      CLASP, ['run', '--nondev'], { encoding: 'utf8' },
+    );
+    expect(result.stdout).to.not.include('Running in dev mode.');
+  });
+  it('should prompt for which function to run', () => {
+    const result = spawnSync(
+      CLASP, ['run'], { encoding: 'utf8' },
+    );
+    expect(result.stdout).to.not.include('Select a functionName.');
+  });
+  it('should not prompt for which function to run', () => {
+    const result = spawnSync(
+      CLASP, ['run', '\'sendEmail\''], { encoding: 'utf8' },
+    );
+    expect(result.stdout).to.not.include('Select a functionName.');
+  });
+
+  // These tests will remain skipped until they can be fixed.
+  it.skip('should prompt for project ID', () => {
+    const result = spawnSync(
+      CLASP, ['run', 'myFunction'], { encoding: 'utf8' },
+    );
+    expect(result.stdout).to.contain(LOG.ASK_PROJECT_ID);
+  });
+  it.skip('should prompt to set up new OAuth client', () => {
+    fs.writeFileSync(CLASP_PATHS.settingsLocal, CLASP_SETTINGS.invalid);
+    const result = spawnSync(
+      CLASP, ['run', 'myFunction'], { encoding: 'utf8' },
+    );
+    fs.removeSync(CLASP_PATHS.settingsLocal);
+    expect(result.stdout)
+      .to.contain('https://console.developers.google.com/apis/credentials?project=');
+    expect(result.status).to.equal(0);
+  });
+  after(cleanup);
+});

--- a/tests/commands/status.ts
+++ b/tests/commands/status.ts
@@ -30,7 +30,7 @@ describe('Test clasp status function', () => {
     const tmpdir = setupTmpDirectory([
       { file: '.claspignore', data: '**/**\n!build/main.js\n!appsscript.json' },
       { file: 'build/main.js', data: TEST_CODE_JS },
-      { file: 'appsscript.json', data: TEST_APPSSCRIPT_JSON },
+      { file: 'appsscript.json', data: TEST_APPSSCRIPT_JSON.withoutRunApi },
       { file: 'shouldBeIgnored', data: TEST_CODE_JS },
       { file: 'should/alsoBeIgnored', data: TEST_CODE_JS },
     ]);
@@ -48,7 +48,7 @@ describe('Test clasp status function', () => {
   it('should ignore dotfiles if the parent folder is ignored', () => {
     const tmpdir = setupTmpDirectory([
       { file: '.claspignore', data: '**/node_modules/**\n**/**\n!appsscript.json' },
-      { file: 'appsscript.json', data: TEST_APPSSCRIPT_JSON },
+      { file: 'appsscript.json', data: TEST_APPSSCRIPT_JSON.withoutRunApi },
       { file: 'node_modules/fsevents/build/Release/.deps/Release/.node.d', data: TEST_CODE_JS },
     ]);
     spawnSync(CLASP, ['create', '[TEST] clasp status'], { encoding: 'utf8', cwd: tmpdir });
@@ -66,7 +66,7 @@ describe('Test clasp status function', () => {
       { file: '.clasp.json', data: '{ "scriptId":"1234", "rootDir":"dist" }' },
       { file: '.claspignore', data: '**/**\n!dist/build/main.js\n!dist/appsscript.json' },
       { file: 'dist/build/main.js', data: TEST_CODE_JS },
-      { file: 'dist/appsscript.json', data: TEST_APPSSCRIPT_JSON },
+      { file: 'dist/appsscript.json', data: TEST_APPSSCRIPT_JSON.withoutRunApi },
       { file: 'dist/shouldBeIgnored', data: TEST_CODE_JS },
       { file: 'dist/should/alsoBeIgnored', data: TEST_CODE_JS },
     ]);

--- a/tests/commands/status.ts
+++ b/tests/commands/status.ts
@@ -7,7 +7,7 @@ import * as path from 'path';
 
 import {
   CLASP,
-  TEST_APPSSCRIPT_JSON,
+  TEST_APPSSCRIPT_JSON_WITHOUT_RUN_API,
   TEST_CODE_JS,
 } from '../constants';
 
@@ -30,7 +30,7 @@ describe('Test clasp status function', () => {
     const tmpdir = setupTmpDirectory([
       { file: '.claspignore', data: '**/**\n!build/main.js\n!appsscript.json' },
       { file: 'build/main.js', data: TEST_CODE_JS },
-      { file: 'appsscript.json', data: TEST_APPSSCRIPT_JSON.withoutRunApi },
+      { file: 'appsscript.json', data: TEST_APPSSCRIPT_JSON_WITHOUT_RUN_API },
       { file: 'shouldBeIgnored', data: TEST_CODE_JS },
       { file: 'should/alsoBeIgnored', data: TEST_CODE_JS },
     ]);
@@ -48,7 +48,7 @@ describe('Test clasp status function', () => {
   it('should ignore dotfiles if the parent folder is ignored', () => {
     const tmpdir = setupTmpDirectory([
       { file: '.claspignore', data: '**/node_modules/**\n**/**\n!appsscript.json' },
-      { file: 'appsscript.json', data: TEST_APPSSCRIPT_JSON.withoutRunApi },
+      { file: 'appsscript.json', data: TEST_APPSSCRIPT_JSON_WITHOUT_RUN_API },
       { file: 'node_modules/fsevents/build/Release/.deps/Release/.node.d', data: TEST_CODE_JS },
     ]);
     spawnSync(CLASP, ['create', '[TEST] clasp status'], { encoding: 'utf8', cwd: tmpdir });
@@ -66,7 +66,7 @@ describe('Test clasp status function', () => {
       { file: '.clasp.json', data: '{ "scriptId":"1234", "rootDir":"dist" }' },
       { file: '.claspignore', data: '**/**\n!dist/build/main.js\n!dist/appsscript.json' },
       { file: 'dist/build/main.js', data: TEST_CODE_JS },
-      { file: 'dist/appsscript.json', data: TEST_APPSSCRIPT_JSON.withoutRunApi },
+      { file: 'dist/appsscript.json', data: TEST_APPSSCRIPT_JSON_WITHOUT_RUN_API },
       { file: 'dist/shouldBeIgnored', data: TEST_CODE_JS },
       { file: 'dist/should/alsoBeIgnored', data: TEST_CODE_JS },
     ]);

--- a/tests/constants.ts
+++ b/tests/constants.ts
@@ -10,13 +10,13 @@ import { OAuth2ClientOptions } from 'google-auth-library';
 // Sample files
 export const TEST_CODE_JS = 'function test() { Logger.log(\'test\'); }';
 
-const APPSSCRIPT_JSON_WITHOUT_RUN = JSON.stringify({
+export const TEST_APPSSCRIPT_JSON_WITHOUT_RUN_API = JSON.stringify({
   timeZone: 'America/Los_Angeles',
   dependencies: {},
   exceptionLogging: 'STACKDRIVER',
 });
 
-const APPSSCRIPT_JSON_WITH_RUN = JSON.stringify({
+export const TEST_APPSSCRIPT_JSON_WITH_RUN_API = JSON.stringify({
   timeZone: 'America/Los_Angeles',
   dependencies: {},
   exceptionLogging: 'STACKDRIVER',
@@ -24,11 +24,6 @@ const APPSSCRIPT_JSON_WITH_RUN = JSON.stringify({
     access: 'MYSELF',
   },
 });
-
-export const TEST_APPSSCRIPT_JSON = {
-  withoutRunApi: APPSSCRIPT_JSON_WITHOUT_RUN,
-  withRunApi: APPSSCRIPT_JSON_WITH_RUN,
-};
 
 // Travis Env Variables
 export const IS_PR: boolean = (process.env.TRAVIS_PULL_REQUEST === 'true');

--- a/tests/constants.ts
+++ b/tests/constants.ts
@@ -9,11 +9,26 @@ import { OAuth2ClientOptions } from 'google-auth-library';
 
 // Sample files
 export const TEST_CODE_JS = 'function test() { Logger.log(\'test\'); }';
-export const TEST_APPSSCRIPT_JSON = JSON.stringify({
+
+const APPSSCRIPT_JSON_WITHOUT_RUN = JSON.stringify({
   timeZone: 'America/Los_Angeles',
   dependencies: {},
   exceptionLogging: 'STACKDRIVER',
 });
+
+const APPSSCRIPT_JSON_WITH_RUN = JSON.stringify({
+  timeZone: 'America/Los_Angeles',
+  dependencies: {},
+  exceptionLogging: 'STACKDRIVER',
+  executionApi: {
+    access: 'MYSELF',
+  },
+});
+
+export const TEST_APPSSCRIPT_JSON = {
+  withoutRunApi: APPSSCRIPT_JSON_WITHOUT_RUN,
+  withRunApi: APPSSCRIPT_JSON_WITH_RUN,
+};
 
 // Travis Env Variables
 export const IS_PR: boolean = (process.env.TRAVIS_PULL_REQUEST === 'true');

--- a/tests/functions.ts
+++ b/tests/functions.ts
@@ -2,7 +2,8 @@ import * as fs from 'fs-extra';
 import {
   CLASP_SETTINGS,
   CLASP_PATHS,
-  TEST_APPSSCRIPT_JSON,
+  TEST_APPSSCRIPT_JSON_WITHOUT_RUN_API,
+  TEST_APPSSCRIPT_JSON_WITH_RUN_API,
 } from './constants';
 
 const copyFileSync = require('fs-copy-file-sync');
@@ -16,17 +17,17 @@ export const cleanup = () => {
 
 export const setup = () => {
   fs.writeFileSync('.clasp.json', CLASP_SETTINGS.valid);
-  fs.writeFileSync('appsscript.json', TEST_APPSSCRIPT_JSON.withoutRunApi);
+  fs.writeFileSync('appsscript.json', TEST_APPSSCRIPT_JSON_WITHOUT_RUN_API);
 };
 
 export const setupWithoutGCPProject = () => {
   fs.writeFileSync('.clasp.json', CLASP_SETTINGS.validWithoutProjectId);
-  fs.writeFileSync('appsscript.json', TEST_APPSSCRIPT_JSON);
+  fs.writeFileSync('appsscript.json', TEST_APPSSCRIPT_JSON_WITHOUT_RUN_API);
 };
 
 export const setupWithRunManifest = () => {
   fs.writeFileSync('.clasp.json', CLASP_SETTINGS.valid);
-  fs.writeFileSync('appsscript.json', TEST_APPSSCRIPT_JSON.withRunApi);
+  fs.writeFileSync('appsscript.json', TEST_APPSSCRIPT_JSON_WITH_RUN_API);
 };
 
 export const rndStr = () => Math.random().toString(36).substr(2);

--- a/tests/functions.ts
+++ b/tests/functions.ts
@@ -16,12 +16,17 @@ export const cleanup = () => {
 
 export const setup = () => {
   fs.writeFileSync('.clasp.json', CLASP_SETTINGS.valid);
-  fs.writeFileSync('appsscript.json', TEST_APPSSCRIPT_JSON);
+  fs.writeFileSync('appsscript.json', TEST_APPSSCRIPT_JSON.withoutRunApi);
 };
 
 export const setupWithoutGCPProject = () => {
   fs.writeFileSync('.clasp.json', CLASP_SETTINGS.validWithoutProjectId);
   fs.writeFileSync('appsscript.json', TEST_APPSSCRIPT_JSON);
+};
+
+export const setupWithRunManifest = () => {
+  fs.writeFileSync('.clasp.json', CLASP_SETTINGS.valid);
+  fs.writeFileSync('appsscript.json', TEST_APPSSCRIPT_JSON.withRunApi);
 };
 
 export const rndStr = () => Math.random().toString(36).substr(2);

--- a/tests/manifest.ts
+++ b/tests/manifest.ts
@@ -1,0 +1,45 @@
+import { expect } from 'chai';
+import { describe, it } from 'mocha';
+
+import {
+  cleanup,
+  setup,
+  setupWithRunManifest,
+} from './functions';
+
+import {
+  getManifest,
+  isValidManifest,
+  isValidRunManifest,
+} from '../src/manifest';
+
+describe('Test getManifest function', () => {
+  before(setup);
+  it('should get a valid manifest file correctly', async () => {
+    const manifest = await getManifest();
+    expect(manifest.timeZone).to.equal('America/Los_Angeles');
+  });
+  after(cleanup);
+});
+
+describe('Test isValidRunManifest function', () => {
+  it('should validate a manifest with run permissions', async () => {
+    setupWithRunManifest();
+    expect(await isValidRunManifest()).to.equal(true);
+    cleanup();
+  });
+  it('should not validate a manifest with run permissions', async () => {
+    setup();
+    expect(await isValidRunManifest()).to.equal(false);
+    cleanup();
+  });
+  after(cleanup);
+});
+
+describe('Test isValidManifest function', () => {
+  before(setup);
+  it('should validate a manifest', async () => {
+    expect(await isValidManifest()).to.equal(true);
+  });
+  after(cleanup);
+});

--- a/tests/test.ts
+++ b/tests/test.ts
@@ -19,7 +19,6 @@ import {
 
 import {
   CLASP,
-  CLASP_SETTINGS,
   CLASP_USAGE,
   CLASP_PATHS,
   IS_PR,
@@ -255,33 +254,6 @@ describe('Test saveProject function from utils', () => {
     };
     expect(isSaved).to.not.equal(null);
   });
-});
-
-// Skipping for now because you still need to deploy function using GUI
-describe.skip('Test clasp run function', () => {
-  before(function () {
-    if (IS_PR) {
-      this.skip();
-    }
-    setup();
-  });
-  it('should prompt for project ID', () => {
-    const result = spawnSync(
-      CLASP, ['run', 'myFunction'], { encoding: 'utf8' },
-    );
-    expect(result.stdout).to.contain(LOG.ASK_PROJECT_ID);
-  });
-  it('should prompt to set up new OAuth client', () => {
-    fs.writeFileSync(CLASP_PATHS.settingsLocal, CLASP_SETTINGS.invalid);
-    const result = spawnSync(
-      CLASP, ['run', 'myFunction'], { encoding: 'utf8' },
-    );
-    fs.removeSync(CLASP_PATHS.settingsLocal);
-    expect(result.stdout)
-      .to.contain('https://console.developers.google.com/apis/credentials?project=');
-    expect(result.status).to.equal(0);
-  });
-  after(cleanup);
 });
 
 describe('Test variations of clasp help', () => {

--- a/tests/utils.ts
+++ b/tests/utils.ts
@@ -1,0 +1,23 @@
+import { expect } from 'chai';
+import { describe, it } from 'mocha';
+
+import {
+  cleanup,
+  setup,
+} from './functions';
+
+import {
+  ERROR,
+  getValidJSON,
+} from '../src/utils';
+
+describe('Test getValidJSON function', () => {
+  before(setup);
+  it('should parse valid params and throw exception for invalid params', () => {
+    const validExampleJSONString = JSON.stringify({ param: 'value' });
+    const invalidExampleJSONString = 'badString';
+    expect(getValidJSON(validExampleJSONString)).to.eql(JSON.parse(validExampleJSONString));
+    expect(() => getValidJSON(invalidExampleJSONString)).to.throw(ERROR.INVALID_JSON);
+  });
+  after(cleanup);
+});


### PR DESCRIPTION
Refactors the `clasp run` tests, as well as a number of functions within `run.ts` and `manifest.ts`. Comments inline.

Increases overall coverage from:

```
-----------------|----------|----------|----------|----------|-------------------|
File             |  % Stmts | % Branch |  % Funcs |  % Lines | Uncovered Line #s |
-----------------|----------|----------|----------|----------|-------------------|
All files        |    73.85 |    49.83 |    77.17 |    75.66 |                   |
 src             |    67.84 |    54.69 |    62.69 |    70.31 |                   |
```
to
```
-----------------|----------|----------|----------|----------|-------------------|
File             |  % Stmts | % Branch |  % Funcs |  % Lines | Uncovered Line #s |
-----------------|----------|----------|----------|----------|-------------------|
All files        |    76.69 |    52.55 |    81.22 |    78.38 |                   |
 src             |    71.22 |    59.23 |    68.61 |    73.78 |                   |
```

Specifically, `clasp run` coverage from:

`  run.ts         |    12.33 |        0 |        0 |    13.11 |`

to

`run.ts         |    37.68 |    11.54 |       50 |    35.09 |`

and manifest from:

`manifest.ts    |    62.96 |    54.17 |    66.67 |    65.08 |`

to

`manifest.ts    |    67.05 |    60.71 |    72.73 |    69.12 |`

and utils from:

`utils.ts       |    66.67 |    53.93 |    61.67 |    65.71 |`

to

`utils.ts       |     67.5 |    56.18 |     62.3 |    66.67 |`

Signed-off-by: campionfellin <campionfellin@gmail.com>

- [x] `npm run test` succeeds.
- [x] `npm run lint` succeeds.
- [ ] Appropriate changes to README are included in PR.
