### PR TITLE
Bump up ts2gas version to 1.6.1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5545,9 +5545,9 @@
       "dev": true
     },
     "ts2gas": {
-      "version": "1.6.0",
-      "resolved": "https://registry.npmjs.org/ts2gas/-/ts2gas-1.6.0.tgz",
-      "integrity": "sha512-YapSoKYSqOVEfdnShdk9vNCXITlaHyRwi7a1KpariboUUCSYvNEeirQLPqVF/YVOjRDpcqeB3wrn4XP2w304LQ==",
+      "version": "1.6.1",
+      "resolved": "https://registry.npmjs.org/ts2gas/-/ts2gas-1.6.1.tgz",
+      "integrity": "sha512-jtdJAbyToDw26AInQ6PTgOt4249PwTzBlLKQhtck0nm2C3x5pYFvvrdiMqe7cZeVb3TOfaf15giyZox9us+MtQ==",
       "requires": {
         "typescript": "^3.2.2"
       }

--- a/package.json
+++ b/package.json
@@ -65,7 +65,7 @@
     "recursive-readdir": "^2.2.2",
     "split-lines": "^1.1.0",
     "string.prototype.padend": "^3.0.0",
-    "ts2gas": "1.6.0",
+    "ts2gas": "1.6.1",
     "ucfirst": "^1.0.0",
     "url": "^0.11.0",
     "watch": "^1.0.2"


### PR DESCRIPTION
Fixes #568 

Details : https://github.com/grant/ts2gas/issues/29#issuecomment-471687980

- [x] `npm run test` succeeds.
- [x] `npm run lint` succeeds.
- [ ] Appropriate changes to README are included in PR.
