### PR TITLE
Fix: prompted for script types when with parentId

### DIFF
--- a/src/commands/create.ts
+++ b/src/commands/create.ts
@@ -43,7 +43,7 @@ export default async (cmd: { type: string; title: string; parentId: string; root
   let { type } = cmd;
   let { parentId } = cmd;
 
-  if (!type) {
+  if (!parentId && !type) {
     const answers = await prompt([{
       type: 'list',
       name: 'type',

--- a/tests/commands/create.ts
+++ b/tests/commands/create.ts
@@ -44,3 +44,16 @@ describe.skip('Test clasp create <title> function', () => {
     expect(result.status).to.equal(0);
   });
 });
+
+describe('Test clasp create <parentId> function', () => {
+  before(setup);
+  it('should not prompt for script types with parentId', () => {
+    spawnSync('rm', ['.clasp.json']);
+    const result = spawnSync(
+      CLASP, ['create', '--parentId', '"1D_Gxyv*****************************NXO7o"'], { encoding: 'utf8' },
+    );
+    expect(result.stdout).to.not.contain(LOG.CLONE_SCRIPT_QUESTION);
+    expect(result.stderr).to.contain('Request contains an invalid argument.');
+  });
+  after(cleanup);
+});


### PR DESCRIPTION
Fixes #575

If use parentId parameter, prompt for types is not required.

- [x] `npm run test` succeeds.
- [x] `npm run lint` succeeds.
- [ ] Appropriate changes to README are included in PR.
