### PR TITLE
refactor: Move clasp * --help test to one test with many assertions

### DIFF
--- a/tests/test.ts
+++ b/tests/test.ts
@@ -40,23 +40,25 @@ describe('Test --help for each function', () => {
     expect(result.status).to.equal(0);
     expect(result.stdout).to.include(expected);
   };
-  it('should run --help', () => expectHelp('run', 'Run a function in your Apps Scripts project'));
-  it('should logs --help', () => expectHelp('logs', 'Shows the StackDriver logs'));
-  it('should login --help', () => expectHelp('login', 'Log in to script.google.com'));
-  it('should logout --help', () => expectHelp('logout', 'Log out'));
-  it('should create --help', () => expectHelp('create', 'Create a script'));
-  it('should clone --help', () => expectHelp('clone', 'Clone a project'));
-  it('should pull --help', () => expectHelp('pull', 'Fetch a remote project'));
-  it('should push --help', () => expectHelp('push', 'Update the remote project'));
-  it('should status --help', () => expectHelp('status', 'Lists files that will be pushed by clasp'));
-  it('should open --help', () => expectHelp('open', 'Open a script'));
-  it('should deployments --help', () => expectHelp('deployments', 'List deployment ids of a script'));
-  it('should undeploy --help', () => expectHelp('undeploy', 'Undeploy a deployment of a project'));
-  it('should versions --help', () => expectHelp('versions', 'List versions of a script'));
-  it('should version --help', () => expectHelp('version', 'Creates an immutable version of the script'));
-  it('should list --help', () => expectHelp('list', 'List App Scripts projects'));
-  it('should apis --help', () => expectHelp('apis', 'List, enable, or disable APIs'));
-  it('should help --help', () => expectHelp('help', 'Display help'));
+  it('should print help for clasp * --help', () => {
+    expectHelp('run', 'Run a function in your Apps Scripts project');
+    expectHelp('logs', 'Shows the StackDriver logs');
+    expectHelp('login', 'Log in to script.google.com');
+    expectHelp('logout', 'Log out');
+    expectHelp('create', 'Create a script');
+    expectHelp('clone', 'Clone a project');
+    expectHelp('pull', 'Fetch a remote project');
+    expectHelp('push', 'Update the remote project');
+    expectHelp('status', 'Lists files that will be pushed by clasp');
+    expectHelp('open', 'Open a script');
+    expectHelp('deployments', 'List deployment ids of a script');
+    expectHelp('undeploy', 'Undeploy a deployment of a project');
+    expectHelp('versions', 'List versions of a script');
+    expectHelp('version', 'Creates an immutable version of the script');
+    expectHelp('list', 'List App Scripts projects');
+    expectHelp('apis', 'List, enable, or disable APIs');
+    expectHelp('help', 'Display help');
+  });
 });
 
 describe('Test extractScriptId function', () => {


### PR DESCRIPTION
Move clasp * --help test to one test with many assertions.

Helps with #593.

---

This actually isn't helping yet:

```
Test --help for each function
    ✓ should print help for clasp * --help (85076ms)
```