### PR TITLE
Reduce number of test jobs from 8 to 3

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,10 +1,10 @@
 sudo: required
 os:
 - linux
-- osx
+# - osx
 language: node_js
 node_js:
-- node
+# - node
 - '10'
 - '8'
 - '6'

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,10 +4,9 @@ os:
 # - osx
 language: node_js
 node_js:
-# - node
+- node
 - '10'
 - '8'
-- '6'
 env:
   global:
   - SCRIPT_ID=1EwE84eZCSBPcaAiJzCnDjmxMVnLQrDyhSKq1oZY6q-3x4BIDHgQefCnL


### PR DESCRIPTION
- Reduce the number of Travis jobs to prevent API resources from being exhausted.
- Keep core job types. Removed job types don't uniquely fail.

@erickoledadevrel What do you think of this mitigation of Travis failures?