### PR TITLE
Refactor clasp pull test

### DIFF
--- a/tests/commands/pull.ts
+++ b/tests/commands/pull.ts
@@ -1,0 +1,25 @@
+import { expect } from 'chai';
+import { describe, it } from 'mocha';
+const { spawnSync } = require('child_process');
+
+import {
+  CLASP,
+} from '../constants';
+
+import {
+  cleanup,
+  setup,
+} from '../functions';
+
+describe('Test clasp pull function', () => {
+  before(setup);
+  it('should pull an existing project correctly', () => {
+    const result = spawnSync(
+      CLASP, ['pull'], { encoding: 'utf8' },
+    );
+    expect(result.stdout).to.contain('Cloned');
+    expect(result.stdout).to.contain('files.');
+    expect(result.status).to.equal(0);
+  });
+  after(cleanup);
+});

--- a/tests/test.ts
+++ b/tests/test.ts
@@ -66,24 +66,6 @@ describe('Test extractScriptId function', () => {
   });
 });
 
-describe('Test clasp pull function', () => {
-  before(function () {
-    if (IS_PR) {
-      this.skip();
-    }
-    setup();
-  });
-  it('should pull an existing project correctly', () => {
-    const result = spawnSync(
-      CLASP, ['pull'], { encoding: 'utf8' },
-    );
-    expect(result.stdout).to.contain('Cloned');
-    expect(result.stdout).to.contain('files.');
-    expect(result.status).to.equal(0);
-  });
-  after(cleanup);
-});
-
 describe('Test URL utils function', () => {
   it('should create Script URL correctly', () => {
     const expectedUrl = `https://script.google.com/d/${SCRIPT_ID}/edit`;


### PR DESCRIPTION
Improves readability of tests.

Signed-off-by: campionfellin <campionfellin@gmail.com>

- [x] `npm run test` succeeds.
- [x] `npm run lint` succeeds.
- [ ] Appropriate changes to README are included in PR.
