### PR TITLE
Refactor clasp setting test

### DIFF
--- a/tests/commands/setting.ts
+++ b/tests/commands/setting.ts
@@ -1,0 +1,51 @@
+import { expect } from 'chai';
+import * as fs from 'fs-extra';
+import { describe, it } from 'mocha';
+const { spawnSync } = require('child_process');
+
+import {
+  CLASP,
+} from '../constants';
+
+import {
+  cleanup,
+  setup,
+} from '../functions';
+
+import { ERROR } from '../../src/utils';
+
+describe('Test setting function', () => {
+  before(setup);
+  it('should return current setting value', () => {
+    const result = spawnSync(
+      CLASP, ['setting', 'scriptId'], { encoding: 'utf8' },
+    );
+
+    expect(result.stdout).to.equal(process.env.SCRIPT_ID);
+  });
+  it('should update .clasp.json with provided value', () => {
+    const result = spawnSync(
+      CLASP, ['setting', 'scriptId', 'test'], { encoding: 'utf8' },
+    );
+    const fileContents = fs.readFileSync('.clasp.json', 'utf8');
+    expect(result.stdout).to.contain('Updated "scriptId":');
+    expect(result.stdout).to.contain('→ "test"');
+    expect(fileContents).to.contain('"test"');
+  });
+  it('should error on unknown keys', () => {
+    // Test getting
+    let result = spawnSync(
+      CLASP, ['setting', 'foo'], { encoding: 'utf8' },
+    );
+    expect(result.status).to.equal(1);
+    expect(result.stderr).to.contain(ERROR.UNKNOWN_KEY('foo'));
+
+    // Test setting
+    result = spawnSync(
+      CLASP, ['setting', 'bar', 'foo'], { encoding: 'utf8' },
+    );
+    expect(result.status).to.equal(1);
+    expect(result.stderr).to.contain(ERROR.UNKNOWN_KEY('bar'));
+  });
+  after(cleanup);
+});

--- a/tests/test.ts
+++ b/tests/test.ts
@@ -129,47 +129,6 @@ describe('Test clasp version and versions function', () => {
   after(cleanup);
 });
 
-describe('Test setting function', () => {
-  before(function () {
-    if (IS_PR) {
-      this.skip();
-    }
-    setup();
-  });
-  it('should return current setting value', () => {
-    const result = spawnSync(
-      CLASP, ['setting', 'scriptId'], { encoding: 'utf8' },
-    );
-
-    expect(result.stdout).to.equal(process.env.SCRIPT_ID);
-  });
-  it('should update .clasp.json with provided value', () => {
-    const result = spawnSync(
-      CLASP, ['setting', 'scriptId', 'test'], { encoding: 'utf8' },
-    );
-    const fileContents = fs.readFileSync('.clasp.json', 'utf8');
-    expect(result.stdout).to.contain('Updated "scriptId":');
-    expect(result.stdout).to.contain('→ "test"');
-    expect(fileContents).to.contain('"test"');
-  });
-  it('should error on unknown keys', () => {
-    // Test getting
-    let result = spawnSync(
-      CLASP, ['setting', 'foo'], { encoding: 'utf8' },
-    );
-    expect(result.status).to.equal(1);
-    expect(result.stderr).to.contain(ERROR.UNKNOWN_KEY('foo'));
-
-    // Test setting
-    result = spawnSync(
-      CLASP, ['setting', 'bar', 'foo'], { encoding: 'utf8' },
-    );
-    expect(result.status).to.equal(1);
-    expect(result.stderr).to.contain(ERROR.UNKNOWN_KEY('bar'));
-  });
-  after(cleanup);
-});
-
 describe('Test getAppsScriptFileName function from files', () => {
   it('should return the basename correctly', () => {
     expect(getAppsScriptFileName('./', 'appsscript.json')).to.equal('appsscript');


### PR DESCRIPTION
Continues test refactoring effort.

Signed-off-by: campionfellin <campionfellin@gmail.com>

- [x] `npm run test` succeeds.
- [x] `npm run lint` succeeds.
- [ ] Appropriate changes to README are included in PR.
