### PR TITLE
Performance tuning for getProjectFiles

### DIFF
--- a/src/files.ts
+++ b/src/files.ts
@@ -89,13 +89,20 @@ export async function getProjectFiles(rootDir: string = path.join('.', '/'), cal
     let ignoredFilePaths: string[] = [];
     ignoredFilePaths = ignoredFilePaths.concat(ignorePatterns);
 
+    // Replace OS specific path separator to common '/' char for console output
+    filePaths = filePaths.map((name) => name.replace(/\\/g, '/'));
+
+    // check ignore files
+    const ignoreMatches = multimatch(filePaths, ignorePatterns, { dot: true });
+    const intersection: string[] = filePaths.filter(file => !ignoreMatches.includes(file));
+
     // Check if there are files that will conflict if renamed .gs to .js.
     // When pushing to Apps Script, these files will overwrite each other.
-    filePaths.map((name: string) => {
+    intersection.map((name: string) => {
       const fileNameWithoutExt = name.slice(0, -path.extname(name).length);
       if (
-        filePaths.indexOf(fileNameWithoutExt + '.js') !== -1 &&
-        filePaths.indexOf(fileNameWithoutExt + '.gs') !== -1
+        intersection.indexOf(fileNameWithoutExt + '.js') !== -1 &&
+        intersection.indexOf(fileNameWithoutExt + '.gs') !== -1
       ) {
         // Can't rename, conflicting files
         abortPush = true;
@@ -106,13 +113,6 @@ export async function getProjectFiles(rootDir: string = path.join('.', '/'), cal
       }
     });
     if (abortPush) return callback(new Error(), null, null);
-
-    // Replace OS specific path separator to common '/' char for console output
-    filePaths = filePaths.map((name) => name.replace(/\\/g, '/'));
-
-    // check ignore files
-    const ignoreMatches = multimatch(filePaths, ignorePatterns, { dot: true });
-    const intersection: string[] = filePaths.filter(file => !ignoreMatches.includes(file));
 
     // Loop through files that are not ignored
     let files = intersection


### PR DESCRIPTION
Relate #610 

In `getProjectFiles`, the process of checking for file name conflicts is very heavy.
However, this process was placed before filtering files using ignore.
That is, this process was applied to a large number of files (for example, files in `node_modules`), and spend long time.

Therefore, Ie speeded up by replacing the processing order.
The process of checking for file name conflicts is running before filtering words by ignore.

- [x] `npm run test` succeeds.
- [x] `npm run lint` succeeds.
- [ ] Appropriate changes to README are included in PR.
