### PR TITLE
Logs detailed view

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,7 +99,7 @@ clasp
 
 > **NOTE**: These commands require you to add your [Project ID](#projectid-optional).
 
-- [`clasp logs [--json] [--open] [--setup] [--watch] [--detailed]`](#logs)
+- [`clasp logs [--json] [--open] [--setup] [--watch] [--simplified]`](#logs)
 - [`clasp apis list`](#apis)
 - [`clasp apis enable <api>`](#apis)
 - [`clasp apis disable <api>`](#apis)
@@ -338,7 +338,7 @@ Prints out most recent the _StackDriver logs_. These are logs from `console.log`
 - `--open`: Open StackDriver logs in a browser.
 - `--setup`: Setup StackDriver logs.
 - `--watch`: Retrieves the newest logs every 5 seconds.
-- `--detailed`: Adds timestamps to the logs.
+- `--simplified`: Removes timestamps to the logs.
 
 #### Examples
 
@@ -351,7 +351,7 @@ ERROR      myFunction      error message
 - `clasp logs --json`
 - `clasp logs --open`
 - `clasp logs --watch`
-- `clasp logs --detailed`
+- `clasp logs --simplified`
 
 ### Run
 

--- a/README.md
+++ b/README.md
@@ -99,7 +99,7 @@ clasp
 
 > **NOTE**: These commands require you to add your [Project ID](#projectid-optional).
 
-- [`clasp logs [--json] [--open] [--setup] [--watch]`](#logs)
+- [`clasp logs [--json] [--open] [--setup] [--watch] [--detailed]`](#logs)
 - [`clasp apis list`](#apis)
 - [`clasp apis enable <api>`](#apis)
 - [`clasp apis disable <api>`](#apis)
@@ -338,18 +338,20 @@ Prints out most recent the _StackDriver logs_. These are logs from `console.log`
 - `--open`: Open StackDriver logs in a browser.
 - `--setup`: Setup StackDriver logs.
 - `--watch`: Retrieves the newest logs every 5 seconds.
+- `--detailed`: Adds timestamps to the logs.
 
 #### Examples
 
 ```text
 clasp logs
-ERROR Sat Apr 07 2019 10:58:31 GMT-0700 (PDT) myFunction      my log error
-INFO  Sat Apr 07 2019 10:58:31 GMT-0700 (PDT) myFunction      info message
+DEBUG      myFunction      my debug message
+ERROR      myFunction      error message
 ```
 
 - `clasp logs --json`
 - `clasp logs --open`
 - `clasp logs --watch`
+- `clasp logs --detailed`
 
 ### Run
 

--- a/README.md
+++ b/README.md
@@ -344,8 +344,8 @@ Prints out most recent the _StackDriver logs_. These are logs from `console.log`
 
 ```text
 clasp logs
-DEBUG      myFunction      my debug message
-ERROR      myFunction      error message
+ERROR Sat Apr 07 2019 10:58:31 GMT-0700 (PDT) myFunction      my log error
+INFO  Sat Apr 07 2019 10:58:31 GMT-0700 (PDT) myFunction      info message
 ```
 
 - `clasp logs --json`

--- a/README.md
+++ b/README.md
@@ -338,7 +338,7 @@ Prints out most recent the _StackDriver logs_. These are logs from `console.log`
 - `--open`: Open StackDriver logs in a browser.
 - `--setup`: Setup StackDriver logs.
 - `--watch`: Retrieves the newest logs every 5 seconds.
-- `--simplified`: Removes timestamps to the logs.
+- `--simplified`: Removes timestamps from the logs.
 
 #### Examples
 

--- a/src/commands/logs.ts
+++ b/src/commands/logs.ts
@@ -16,7 +16,7 @@ const padEnd = require('string.prototype.padend');
  * @param cmd.open {boolean} If true, the command will open the StackDriver logs website.
  * @param cmd.setup {boolean} If true, the command will help you setup logs.
  * @param cmd.watch {boolean} If true, the command will watch for logs and print them. Exit with ^C.
- * @param cmd.detailed {boolean} If true, the command will add timestamps to the logs.
+ * @param cmd.simplified {boolean} If true, the command will add timestamps to the logs.
  */
 export default async (
   cmd: {
@@ -24,11 +24,10 @@ export default async (
     open: boolean;
     setup: boolean;
     watch: boolean;
-    detailed: boolean;
+    simplified: boolean;
   },
 ) => {
   await checkIfOnline();
-
   // Get project settings.
   let { projectId } = await getProjectSettings();
   projectId = cmd.setup ? await setupLogs() : projectId;
@@ -50,10 +49,10 @@ export default async (
     setInterval(() => {
       const startDate = new Date();
       startDate.setSeconds(startDate.getSeconds() - (10 * POLL_INTERVAL) / 1000);
-      fetchAndPrintLogs(cmd.json, cmd.detailed, projectId, startDate);
+      fetchAndPrintLogs(cmd.json, cmd.simplified, projectId, startDate);
     }, POLL_INTERVAL);
   } else {
-    fetchAndPrintLogs(cmd.json, cmd.detailed, projectId);
+    fetchAndPrintLogs(cmd.json, cmd.simplified, projectId);
   }
 };
 
@@ -65,7 +64,7 @@ export default async (
 export function printLogs(
   entries: logging_v2.Schema$LogEntry[] = [],
   formatJson: boolean,
-  detailed: boolean,
+  simplified: boolean,
 ) {
   /**
    * This object holds all log IDs that have been printed to the user.
@@ -122,10 +121,10 @@ export function printLogs(
     coloredSeverity = padEnd(String(coloredSeverity), 20);
     // If we haven't logged this entry before, log it and mark the cache.
     if (!logEntryCache[insertId]) {
-      if (detailed) {
-        console.log(`${coloredSeverity} ${timestamp} ${functionName} ${payloadData}`);
-      } else {
+      if (simplified) {
         console.log(`${coloredSeverity} ${functionName} ${payloadData}`);
+      } else {
+        console.log(`${coloredSeverity} ${timestamp} ${functionName} ${payloadData}`);
       }
       logEntryCache[insertId] = true;
     }
@@ -175,7 +174,7 @@ export async function setupLogs(): Promise<string> {
 // TODO: unnecessary export
 export async function fetchAndPrintLogs(
   formatJson: boolean,
-  detailed: boolean,
+  simplified: boolean,
   projectId?: string,
   startDate?: Date,
 ) {
@@ -223,7 +222,7 @@ export async function fetchAndPrintLogs(
             logError(null, `(${logs.status}) Error: ${logs.statusText}`);
         }
       } else {
-        printLogs(logs.data.entries, formatJson, detailed);
+        printLogs(logs.data.entries, formatJson, simplified);
       }
     };
     parseResponse(logs);

--- a/src/commands/logs.ts
+++ b/src/commands/logs.ts
@@ -16,7 +16,7 @@ const padEnd = require('string.prototype.padend');
  * @param cmd.open {boolean} If true, the command will open the StackDriver logs website.
  * @param cmd.setup {boolean} If true, the command will help you setup logs.
  * @param cmd.watch {boolean} If true, the command will watch for logs and print them. Exit with ^C.
- * @param cmd.simplified {boolean} If true, the command will add timestamps to the logs.
+ * @param cmd.simplified {boolean} If true, the command will remove timestamps from the logs.
  */
 export default async (
   cmd: {

--- a/src/commands/logs.ts
+++ b/src/commands/logs.ts
@@ -18,7 +18,15 @@ const padEnd = require('string.prototype.padend');
  * @param cmd.watch {boolean} If true, the command will watch for logs and print them. Exit with ^C.
  * @param cmd.detailed {boolean} If true, the command will add timestamps to the logs.
  */
-export default async (cmd: { json: boolean; open: boolean; setup: boolean; watch: boolean; detailed: boolean; }) => {
+export default async (
+  cmd: {
+    json: boolean;
+    open: boolean;
+    setup: boolean;
+    watch: boolean;
+    detailed: boolean;
+  },
+) => {
   await checkIfOnline();
 
   // Get project settings.
@@ -54,7 +62,11 @@ export default async (cmd: { json: boolean; open: boolean; setup: boolean; watch
  * @param entries {any[]} StackDriver log entries.
  */
 // TODO: unnecessary export
-export function printLogs(entries: logging_v2.Schema$LogEntry[] = [], formatJson: boolean, detailed: boolean) {
+export function printLogs(
+  entries: logging_v2.Schema$LogEntry[] = [],
+  formatJson: boolean,
+  detailed: boolean,
+) {
   /**
    * This object holds all log IDs that have been printed to the user.
    * This prevents log entries from being printed multiple times.
@@ -110,11 +122,11 @@ export function printLogs(entries: logging_v2.Schema$LogEntry[] = [], formatJson
     coloredSeverity = padEnd(String(coloredSeverity), 20);
     // If we haven't logged this entry before, log it and mark the cache.
     if (!logEntryCache[insertId]) {
-        if(detailed){
-          console.log(`${coloredSeverity} ${timestamp} ${functionName} ${payloadData}`);
-        }else{
-          console.log(`${coloredSeverity} ${functionName} ${payloadData}`)
-        }
+      if (detailed) {
+        console.log(`${coloredSeverity} ${timestamp} ${functionName} ${payloadData}`);
+      } else {
+        console.log(`${coloredSeverity} ${functionName} ${payloadData}`);
+      }
       logEntryCache[insertId] = true;
     }
   }
@@ -161,7 +173,12 @@ export async function setupLogs(): Promise<string> {
  * @param startDate {Date?} Get logs from this date to now.
  */
 // TODO: unnecessary export
-export async function fetchAndPrintLogs(formatJson: boolean, timestamps: boolean, projectId?: string, startDate?: Date) {
+export async function fetchAndPrintLogs(
+  formatJson: boolean,
+  detailed: boolean,
+  projectId?: string,
+  startDate?: Date,
+) {
   const oauthSettings = await loadAPICredentials();
   spinner.setSpinnerTitle(`${oauthSettings.isLocalCreds ? LOG.LOCAL_CREDS : ''}${LOG.GRAB_LOGS}`).start();
   // Create a time filter (timestamp >= "2016-11-29T23:00:00Z")
@@ -206,7 +223,7 @@ export async function fetchAndPrintLogs(formatJson: boolean, timestamps: boolean
             logError(null, `(${logs.status}) Error: ${logs.statusText}`);
         }
       } else {
-        printLogs(logs.data.entries, formatJson, timestamps);
+        printLogs(logs.data.entries, formatJson, detailed);
       }
     };
     parseResponse(logs);

--- a/src/index.ts
+++ b/src/index.ts
@@ -269,6 +269,7 @@ commander
   .option('--open', 'Open the StackDriver logs in the browser')
   .option('--setup', 'Setup StackDriver logs')
   .option('--watch', 'Watch and print new logs')
+  .option('--detailed', 'Show timestamps with logs')
   .action(handleError(logs));
 
 /**

--- a/src/index.ts
+++ b/src/index.ts
@@ -269,7 +269,7 @@ commander
   .option('--open', 'Open the StackDriver logs in the browser')
   .option('--setup', 'Setup StackDriver logs')
   .option('--watch', 'Watch and print new logs')
-  .option('--detailed', 'Show timestamps with logs')
+  .option('--simplified', 'Hide timestamps with logs')
   .action(handleError(logs));
 
 /**


### PR DESCRIPTION
Fixes #638 

I've added an optional parameter for the logs command called detailed. 

Timestamps are now disabled by default.
A user must use the `--detailed` command if they want timestamps now.

Works with the `--watch` command as well.

- [x] `npm run test` succeeds.
- [x] `npm run lint` succeeds.
- [x] Appropriate changes to README are included in PR.
