### PR TITLE
Adding notes for claspignore

### DIFF
--- a/README.md
+++ b/README.md
@@ -454,7 +454,7 @@ A sample `.claspignore` ignoring everything except the manifest and `build/main.
 
 _Note_: The `.claspignore` patterns are applied relative from the `rootDir`.
 
-If no `.claspignore` is specified, a default set of patterns is applied. The default will only consider the `appsscript.json` manifest and any JavaScript and TypeScript source files in the `rootDir` folder
+If no `.claspignore` is specified, a default set of patterns is applied. The default will only consider the `appsscript.json` manifest and any JavaScript and TypeScript source files in the `rootDir` folder (child folders are not processed)
 
 ```text
 **/**

--- a/README.md
+++ b/README.md
@@ -454,7 +454,7 @@ A sample `.claspignore` ignoring everything except the manifest and `build/main.
 
 _Note_: The `.claspignore` patterns are applied relative from the `rootDir`.
 
-If no `.claspignore` is specified, a default set of patterns is applied. The default will only consider the `appsscript.json` manifest and any JavaScript and TypeScript source files in the `rootDir` folder (child folders are not processed)
+If no `.claspignore` is specified, a default set of patterns is applied. This default set will only consider the `appsscript.json` manifest and any JavaScript, TypeScript and `.html` source files within the `rootDir` folder. Child folders are not processed.
 
 ```text
 **/**


### PR DESCRIPTION
- [x] Appropriate changes to README are included in PR.

Please consider adding this explanation.

At the first starts, the user expects the command without arguments and settings to send the entire project, although this is not the case. Only root folder files are sent, but not ***child folders*** and their _files_.