### PR TITLE
Login status

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,7 +80,7 @@ The following command provide basic Apps Script project management.
 clasp
 ```
 
-- [`clasp login [--no-localhost] [--creds <file>]`](#login)
+- [`clasp login [--no-localhost] [--creds <file>] [--status]`](#login)
 - [`clasp logout`](#logout)
 - [`clasp create [--title <title>] [--type <type>] [--rootDir <dir>] [--parentId <id>]`](#create)
 - [`clasp clone <scriptId | scriptURL> [versionNumber] [--rootDir <dir>]`](#clone)
@@ -121,11 +121,13 @@ Logs the user in. Saves the client credentials to a `.clasprc.json` file.
 
 - `--no-localhost`: Do not run a local server, manually enter code instead.
 - `--creds <file>`: Use custom credentials used for `clasp run`. Saves a `.clasprc.json` file to current working directory. This file should be private!
+- `--status`: Print who you are currently logged in as, if anyone.
 
 #### Examples
 
 - `clasp login --no-localhost`
 - `clasp login --creds creds.json`
+- `clasp login --status`
 
 ### Logout
 

--- a/src/auth.ts
+++ b/src/auth.ts
@@ -190,10 +190,14 @@ export async function authorize(options: {
 
 export async function getLoggedInEmail() {
   await loadAPICredentials();
-  const response = await google.oauth2('v2').userinfo.get({
-    auth: globalOAuth2Client,
-  });
-  return response.data.email;
+  try {
+    const response = await google.oauth2('v2').userinfo.get({
+      auth: globalOAuth2Client,
+    });
+    return response.data.email;
+  } catch (e) {
+    return undefined;
+  }
 }
 
 /**

--- a/src/auth.ts
+++ b/src/auth.ts
@@ -117,6 +117,8 @@ export async function authorize(options: {
         'https://www.googleapis.com/auth/drive.file', // Create Drive files
         'https://www.googleapis.com/auth/service.management', // Cloud Project Service Management API
         'https://www.googleapis.com/auth/logging.read', // StackDriver logs
+        'https://www.googleapis.com/auth/userinfo.email', // User email address
+        'https://www.googleapis.com/auth/userinfo.profile',
 
         // Extra scope since service.management doesn't work alone
         'https://www.googleapis.com/auth/cloud-platform',
@@ -131,6 +133,8 @@ export async function authorize(options: {
         'https://www.googleapis.com/auth/drive.file', // Create Drive files
         'https://www.googleapis.com/auth/service.management', // Cloud Project Service Management API
         'https://www.googleapis.com/auth/logging.read', // StackDriver logs
+        'https://www.googleapis.com/auth/userinfo.email', // User email address
+        'https://www.googleapis.com/auth/userinfo.profile',
 
         // Extra scope since service.management doesn't work alone
         'https://www.googleapis.com/auth/cloud-platform',

--- a/src/auth.ts
+++ b/src/auth.ts
@@ -184,6 +184,14 @@ export async function authorize(options: {
   }
 }
 
+export async function getLoggedInEmail() {
+  await loadAPICredentials();
+  const response = await google.oauth2('v2').userinfo.get({
+    auth: globalOAuth2Client,
+  });
+  return response.data.email;
+}
+
 /**
  * Loads the Apps Script API credentials for the CLI.
  * Required before every API call.
@@ -324,7 +332,7 @@ export async function checkOauthScopes(rc: ClaspToken) {
     const newScopes =
       oauthScopes && oauthScopes.length ? (oauthScopes).filter(x => !scopes.includes(x)) : [];
     if (!newScopes.length) return;
-    console.log('New authoization scopes detected in manifest:\n', newScopes);
+    console.log('New authorization scopes detected in manifest:\n', newScopes);
 
     await oauthScopesPrompt()
     .then(async (answers) => {

--- a/src/commands/login.ts
+++ b/src/commands/login.ts
@@ -3,63 +3,80 @@
  */
 import { readJsonSync } from 'fs-extra';
 import { enableAppsScriptAPI } from '../apiutils';
-import { authorize } from '../auth';
+import { authorize, getLoggedInEmail } from '../auth';
 import { FS_OPTIONS } from '../files';
 import { readManifest } from '../manifest';
-import { ERROR, LOG, checkIfOnline, hasOauthClientSettings } from '../utils';
+import { ERROR, LOG, checkIfOnline, hasOauthClientSettings, safeIsOnline } from '../utils';
+import { google } from 'googleapis';
 
 /**
  * Logs the user in. Saves the client credentials to an either local or global rc file.
  * @param {object} options The login options.
  * @param {boolean?} options.localhost If true, authorizes without a HTTP server.
  * @param {string?} options.creds The location of credentials file.
+ * @param {boolean?} options.status If true, prints who is logged in instead of doing login.
  */
-export default async (options: { localhost?: boolean; creds?: string }) => {
-  // Local vs global checks
-  const isLocalLogin = !!options.creds;
-  const loggedInLocal = hasOauthClientSettings(true);
-  const loggedInGlobal = hasOauthClientSettings(false);
-  if (isLocalLogin && loggedInLocal) console.error(ERROR.LOGGED_IN_LOCAL);
-  if (!isLocalLogin && loggedInGlobal) console.error(ERROR.LOGGED_IN_GLOBAL);
-  console.log(LOG.LOGIN(isLocalLogin));
-  await checkIfOnline();
+export default async (options: { localhost?: boolean; creds?: string, status?: boolean }) => {
+  if (options.status) {
+    if (hasOauthClientSettings()) {
+      const email = (await safeIsOnline) ? (await getLoggedInEmail()) : undefined;
 
-  // Localhost check
-  const useLocalhost = !!options.localhost;
+      if (!!email) {
+        console.log(LOG.LOGGED_IN_AS(email));
+      } else {
+        console.log(LOG.LOGGED_IN_UNKNOWN);
+      }
+    } else {
+      console.log(LOG.NOT_LOGGED_IN);
+    }
 
-  // Using own credentials.
-  if (options.creds) {
-    let oauthScopes: string[] = [];
-    // First read the manifest to detect any additional scopes in "oauthScopes" fields.
-    // In the script.google.com UI, these are found under File > Project Properties > Scopes
-    const manifest = await readManifest();
-    oauthScopes = manifest.oauthScopes || [];
-    oauthScopes = oauthScopes.concat([
-      'https://www.googleapis.com/auth/script.webapp.deploy', // Scope needed for script.run
-    ]);
-    console.log('');
-    console.log(`Authorizing with the following scopes:`);
-    oauthScopes.forEach(scope => {
-      console.log(scope);
-    });
-    console.log(`
-NOTE: The full list of scopes your project may need can be found at script.google.com under:
-File > Project Properties > Scopes
-`);
-
-    // Read credentials file.
-    const credentials = readJsonSync(options.creds, FS_OPTIONS);
-    await authorize({
-      useLocalhost,
-      creds: credentials,
-      scopes: oauthScopes,
-    });
-    await enableAppsScriptAPI();
+    process.exit(0);
   } else {
-    // Not using own credentials
-    await authorize({
-      useLocalhost,
-      scopes: [
+    // Local vs global checks
+    const isLocalLogin = !!options.creds;
+    const loggedInLocal = hasOauthClientSettings(true);
+    const loggedInGlobal = hasOauthClientSettings(false);
+    if (isLocalLogin && loggedInLocal) console.error(ERROR.LOGGED_IN_LOCAL);
+    if (!isLocalLogin && loggedInGlobal) console.error(ERROR.LOGGED_IN_GLOBAL);
+    console.log(LOG.LOGIN(isLocalLogin));
+    await checkIfOnline();
+
+    // Localhost check
+    const useLocalhost = !!options.localhost;
+
+    // Using own credentials.
+    if (options.creds) {
+      let oauthScopes: string[] = [];
+      // First read the manifest to detect any additional scopes in "oauthScopes" fields.
+      // In the script.google.com UI, these are found under File > Project Properties > Scopes
+      const manifest = await readManifest();
+      oauthScopes = manifest.oauthScopes || [];
+      oauthScopes = oauthScopes.concat([
+        'https://www.googleapis.com/auth/script.webapp.deploy', // Scope needed for script.run
+      ]);
+      console.log('');
+      console.log(`Authorizing with the following scopes:`);
+      oauthScopes.forEach(scope => {
+        console.log(scope);
+      });
+      console.log(`
+  NOTE: The full list of scopes your project may need can be found at script.google.com under:
+  File > Project Properties > Scopes
+  `);
+
+      // Read credentials file.
+      const credentials = readJsonSync(options.creds, FS_OPTIONS);
+      await authorize({
+        useLocalhost,
+        creds: credentials,
+        scopes: oauthScopes,
+      });
+      await enableAppsScriptAPI();
+    } else {
+      // Not using own credentials
+      await authorize({
+        useLocalhost,
+        scopes: [
         // Use the default scopes needed for clasp.
         'https://www.googleapis.com/auth/script.deployments', // Apps Script deployments
         'https://www.googleapis.com/auth/script.projects', // Apps Script management
@@ -75,4 +92,5 @@ File > Project Properties > Scopes
     });
   }
   process.exit(0); // gracefully exit after successful login
+  }
 };

--- a/src/commands/login.ts
+++ b/src/commands/login.ts
@@ -85,6 +85,8 @@ export default async (options: { localhost?: boolean; creds?: string, status?: b
         'https://www.googleapis.com/auth/drive.file', // Create Drive files
         'https://www.googleapis.com/auth/service.management', // Cloud Project Service Management API
         'https://www.googleapis.com/auth/logging.read', // StackDriver logs
+        'https://www.googleapis.com/auth/userinfo.email', // User email address
+        'https://www.googleapis.com/auth/userinfo.profile',
 
         // Extra scope since service.management doesn't work alone
         'https://www.googleapis.com/auth/cloud-platform',

--- a/src/commands/login.ts
+++ b/src/commands/login.ts
@@ -19,7 +19,7 @@ import { google } from 'googleapis';
 export default async (options: { localhost?: boolean; creds?: string, status?: boolean }) => {
   if (options.status) {
     if (hasOauthClientSettings()) {
-      const email = (await safeIsOnline) ? (await getLoggedInEmail()) : undefined;
+      const email = (await safeIsOnline()) ? (await getLoggedInEmail()) : undefined;
 
       if (!!email) {
         console.log(LOG.LOGGED_IN_AS(email));

--- a/src/commands/openCmd.ts
+++ b/src/commands/openCmd.ts
@@ -71,7 +71,6 @@ export default async (
     });
 
   const answers = await deploymentIdPrompt(choices);
-  console.log(JSON.stringify(answers));
   const deployment = await script.projects.deployments.get({
     scriptId,
     deploymentId: answers.deployment.deploymentId,

--- a/src/commands/openCmd.ts
+++ b/src/commands/openCmd.ts
@@ -70,13 +70,13 @@ export default async (
       };
     });
 
-  // tslint:disable-next-line:no-any
-  const answers = (await deploymentIdPrompt(choices)).deploymentId as any;
+  const answers = await deploymentIdPrompt(choices);
+  console.log(JSON.stringify(answers));
   const deployment = await script.projects.deployments.get({
     scriptId,
-    deploymentId: answers.deploymentId,
+    deploymentId: answers.deployment.deploymentId,
   });
-  console.log(LOG.OPEN_WEBAPP(answers.deploymentId));
+  console.log(LOG.OPEN_WEBAPP(answers.deployment.deploymentId));
   const target = getWebApplicationURL(deployment.data);
   if (target) {
     return open(target, { wait: false });

--- a/src/index.ts
+++ b/src/index.ts
@@ -69,6 +69,7 @@ commander
   .description('Log in to script.google.com')
   .option('--no-localhost', 'Do not run a local server, manually enter code instead')
   .option('--creds <file>', 'Relative path to credentials (from GCP).')
+  .option('--status', 'Print who is logged in')
   .action(handleError(login));
 
 /**

--- a/src/inquirer.ts
+++ b/src/inquirer.ts
@@ -32,12 +32,13 @@ interface DeploymentIdPrompt {
  * @param {DeploymentIdPrompt[]} choices An array of `DeploymentIdPrompt` objects.
  * @returns {Promise<{ deploymentId: string }>} A promise for an object with the `deploymentId` property.
  */
-export const deploymentIdPrompt = (choices: DeploymentIdPrompt[]) => prompt<{ deploymentId: string }>([{
-  choices,
-  message: 'Open which deployment?',
-  name: 'deploymentId',
-  type: 'list',
-}]);
+export const deploymentIdPrompt = (choices: DeploymentIdPrompt[]) =>
+  prompt<{ deployment: script_v1.Schema$Deployment }>([{
+    choices,
+    message: 'Open which deployment?',
+    name: 'deployment',
+    type: 'list',
+  }]);
 
 /**
  * Inquirer prompt for a project description.

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -123,6 +123,9 @@ Did you provide the correct projectID?`,
 // Log messages (some logs take required params)
 export const LOG = {
   ASK_PROJECT_ID: `What is your GCP projectId?`,
+  NOT_LOGGED_IN: 'You are not logged in.',
+  LOGGED_IN_UNKNOWN: 'You are logged in as an unknown user.',
+  LOGGED_IN_AS: (email: string) => `You are logged in as ${email}.`,
   AUTH_CODE: 'Enter the code from that page here: ',
   // TODO: Make AUTH_PAGE_SUCCESSFUL show an HTML page with something useful!
   AUTH_PAGE_SUCCESSFUL: `Logged in! You may close this page. `, // HTML Redirect Page
@@ -314,10 +317,21 @@ export function getAPIFileType(filePath: string): string {
 /**
  * Checks if the network is available. Gracefully exits if not.
  */
-export async function checkIfOnline() {
+export async function safeIsOnline() {
   // If using a proxy, return true since `isOnline` doesn't work.
   // @see https://github.com/googleapis/google-api-nodejs-client#using-a-proxy
-  if (process.env.HTTP_PROXY || process.env.HTTPS_PROXY || (await isOnline())) {
+  if (process.env.HTTP_PROXY || process.env.HTTPS_PROXY) {
+    return true;
+  } else {
+    return await isOnline();
+  }
+}
+
+/**
+ * Checks if the network is available. Gracefully exits if not.
+ */
+export async function checkIfOnline() {
+  if (await safeIsOnline()) {
     return true;
   }
   return logError(null, ERROR.OFFLINE);


### PR DESCRIPTION
Fulfils #676. `clasp login --status` which fetches user's email.

- [ ] `npm run test` succeeds.
I wasn't able to get tests working locally in general. Most of them fail. I did set the environment variables but no luck. Would appreciate if someone else could confirm that tests pass.

- [X] `npm run lint` succeeds.
- [X] Appropriate changes to README are included in PR.
