### PR TITLE
The description of scriptId in readme shows projectKey, so we specified how to get scriptId correctly.

### DIFF
--- a/README.md
+++ b/README.md
@@ -492,7 +492,11 @@ The following configuration values can be used:
 
 ### `scriptId` (required)
 
-Specifies the id of the Google Script project that clasp will target. It is the part located inbetween `/d/` and `/edit` in your project's URL: `https://script.google.com/d/<SCRIPT_ID>/edit`.
+Specifies the id of the Google Script project that clasp will target. 
+
+1. Open script url.
+1. File > Project properties > Script ID
+
 
 ### `rootDir` (optional)
 


### PR DESCRIPTION
- [x] `npm run test` succeeds.
- [x] `npm run lint` succeeds.
- [x] Appropriate changes to README are included in PR.

The description of scriptId in readme shows projectKey, so we specified how to get scriptId correctly.