### PR TITLE
Fix `versions` paginate

### DIFF
--- a/src/commands/versions.ts
+++ b/src/commands/versions.ts
@@ -21,7 +21,7 @@ export default async (): Promise<void> => {
     res = await script.projects.versions.list({
       scriptId,
       pageSize: 200,
-      pageToken: pageToken || ''
+      pageToken: pageToken || '',
     });
     if (res && res.data) {
       versions = versions.concat(res.data.versions || []);

--- a/src/commands/versions.ts
+++ b/src/commands/versions.ts
@@ -11,24 +11,37 @@ export default async (): Promise<void> => {
   await loadAPICredentials();
   spinner.setSpinnerTitle('Grabbing versions...').start();
   const { scriptId } = await getProjectSettings();
-  const versions = await script.projects.versions.list({
-    scriptId,
-    pageSize: 500,
-  });
+  let maxPages = 5;
+  /** @type {script_v1.Schema$Version[] | undefined} */
+  let versions = [] as script_v1.Schema$Version[];
+  let res = undefined;
+  /** @type {string | null | undefined} */
+  let pageToken;
+  do {
+    res = await script.projects.versions.list({
+      scriptId,
+      pageSize: 200,
+      pageToken: pageToken || ''
+    });
+    if (res && res.data) {
+      versions = versions.concat(res.data.versions || []);
+      pageToken = res.data.nextPageToken;
+    }
+  } while (pageToken && --maxPages);
+
   if (spinner.isSpinning()) spinner.stop(true);
-  if (versions.status === 200) {
-    const { data } = versions;
-    if (data && data.versions && data.versions.length > 0) {
-      const numVersions = data.versions.length;
+  if (res.status === 200) {
+    if (versions.length > 0) {
+      const numVersions = versions.length;
       console.log(LOG.VERSION_NUM(numVersions));
-      data.versions.reverse();
-      data.versions.forEach((version: script_v1.Schema$Version) => {
+      versions.reverse();
+      versions.forEach((version: script_v1.Schema$Version) => {
         console.log(LOG.VERSION_DESCRIPTION(version));
       });
     } else {
       logError(null, LOG.DEPLOYMENT_DNE);
     }
   } else {
-    logError(versions.statusText);
+    logError(res.statusText);
   }
 };


### PR DESCRIPTION
Fixes #734 

- [ ] `npm run test` succeeds.
- [x] `npm run lint` succeeds.
- [ ] Appropriate changes to README are included in PR.

Up to 1000 versions.