### PR TITLE
Redeployment documentation improvements

### DIFF
--- a/README.md
+++ b/README.md
@@ -275,7 +275,10 @@ List deployments of a script.
 ### Deploy
 
 Creates a version and deploys a script.
-The response gives the version of the deployment.
+The response gives the deployment ID and the version of the deployment.
+
+For web apps, each deployment has a unique URL.
+To update/redeploy an existing deployment, provide the deployment ID.
 
 #### Options
 
@@ -288,7 +291,7 @@ The response gives the version of the deployment.
 - `clasp deploy` (create new deployment and new version)
 - `clasp deploy --versionNumber 4` (create new deployment)
 - `clasp deploy --description "Updates sidebar logo."` (deploy with description)
-- `clasp deploy --deploymentId abcd1234` (create new version)
+- `clasp deploy --deploymentId abcd1234` (redeploy and create new version)
 - `clasp deploy -V 7 -d "Updates sidebar logo." -i abdc1234`
 
 ### Undeploy

--- a/README.md
+++ b/README.md
@@ -288,8 +288,8 @@ The response gives the version of the deployment.
 - `clasp deploy` (create new deployment and new version)
 - `clasp deploy --versionNumber 4` (create new deployment)
 - `clasp deploy --description "Updates sidebar logo."` (deploy with description)
-- `clasp deploy --deploymentId 123` (create new version)
-- `clasp deploy -V 7 -d "Updates sidebar logo." -i 456`
+- `clasp deploy --deploymentId abcd1234` (create new version)
+- `clasp deploy -V 7 -d "Updates sidebar logo." -i abdc1234`
 
 ### Undeploy
 


### PR DESCRIPTION
There seems to be a lot of confusion around redeployments, see #752 and the somewhat unrelated #63 with lots of "related" comments. I hope to help avoid confusion with these small documentation changes. This would have helped me get started with less confusion.

README changes only:
- Add documentation about each web app deployment having a unique URL, and about the need to provide the deployment ID to redeploy it. 
- Change example deployment IDs to alphanumeric to avoid confusing them with version numbers.

CLA signed.