### PR TITLE
Fix the default command's output

### DIFF
--- a/src/commands/defaultCmd.ts
+++ b/src/commands/defaultCmd.ts
@@ -1,9 +1,10 @@
 import { ERROR, logError } from '../utils';
+import { Command } from 'commander';
 
 /**
  * Displays a default message when an unknown command is typed.
  * @param command {string} The command that was typed.
  */
-export default async (command: string): Promise<void> => {
+export default async (_: Command, command: string): Promise<void> => {
   logError(null, ERROR.COMMAND_DNE(command));
 };

--- a/tests/commands/defaultCmd.ts
+++ b/tests/commands/defaultCmd.ts
@@ -1,0 +1,15 @@
+import { spawnSync } from 'child_process';
+import { expect } from 'chai';
+import { describe, it } from 'mocha';
+import { CLASP } from '../constants';
+
+describe('Test missing command function', () => {
+  it('should report missing command correctly', () => {
+    const result = spawnSync(
+      CLASP, ['parboil'], { encoding: 'utf8' },
+    );
+    const expected = `Unknown command "clasp parboil"`;
+    expect(result.stderr).to.contain(expected);
+    expect(result.status).to.equal(1);
+  });
+});


### PR DESCRIPTION
Since the commander upgrade in c805769c04b6dcd8c8ea3eb0e20856655e2dc255, clasp was printing the following when encountering an unknown command:
`Unknown command "clasp [object Object]"`

- [X] `npm run test` succeeds.
- [X] `npm run lint` succeeds.
- [X] Appropriate changes to README are included in PR.
