### PR TITLE
Add npm `prepare` script

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,6 +8,7 @@
     "build-fresh": "npm cache clean --force && npm i && npm run build",
     "build-local": "tsc --project tsconfig.json",
     "watch": "tsc --project tsconfig.json --watch",
+    "prepare": "npm run build-local",
     "publish": "npm publish --access public",
     "lint": "tslint --project tslint.json && echo 'No lint errors. All good!'",
     "test": "nyc mocha -r ts-node/register --cache false --timeout 100000 'tests/**/*.ts'",


### PR DESCRIPTION
Add prepare script so that clasp can be installed directly from the git repo

Fixes #<issue_number_goes_here> (it's a good idea to open an issue first for discussion)

- [ ] `npm run test` succeeds.
- [ ] `npm run lint` succeeds.
- [ ] Appropriate changes to README are included in PR.
