### PR TITLE
feat: use custom deployment ID with `open --webapp`

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,7 +104,7 @@ clasp
 - [`clasp pull [--versionNumber]`](#pull)
 - [`clasp push [--watch] [--force]`](#push)
 - [`clasp status [--json]`](#status)
-- [`clasp open [scriptId] [--webapp] [--creds] [--addon]`](#open)
+- [`clasp open [scriptId] [--webapp] [--creds] [--addon] [--deploymentId <id>]`](#open)
 - [`clasp deployments`](#deployments)
 - [`clasp deploy [--versionNumber <version>] [--description <description>] [--deploymentId <id>]`](#deploy)
 - [`clasp undeploy [deploymentId] [--all]`](#undeploy)
@@ -267,6 +267,7 @@ Opens the current directory's `clasp` project on script.google.com. Provide a `s
 - `--webapp`: Open web application in a browser.
 - `--creds`: Open the URL to create credentials.
 - `--addon`: List parent IDs and open the URL of the first one.
+- `--deploymentId <id>`: Use custom deployment ID (used only with `--webapp`).
 
 #### Examples
 
@@ -275,6 +276,7 @@ Opens the current directory's `clasp` project on script.google.com. Provide a `s
 - `clasp open --webapp`
 - `clasp open --creds`
 - `clasp open --addon`
+- `clasp open --webapp --deploymentId abcd1234`
 
 ### Deployments
 

--- a/README.md
+++ b/README.md
@@ -267,7 +267,7 @@ Opens the current directory's `clasp` project on script.google.com. Provide a `s
 - `--webapp`: Open web application in a browser.
 - `--creds`: Open the URL to create credentials.
 - `--addon`: List parent IDs and open the URL of the first one.
-- `--deploymentId <id>`: Use custom deployment ID (used only with `--webapp`).
+- `--deploymentId <id>`: Use custom deployment ID with `--webapp`.
 
 #### Examples
 

--- a/src/commands/open.ts
+++ b/src/commands/open.ts
@@ -91,10 +91,12 @@ export default async (scriptId: string, options: CommandOption): Promise<void> =
       };
     });
 
-  let { deploymentId } = options;
+  let {deploymentId} = options;
   if (!deploymentId) {
-    const { deployment: { deploymentId: depIdFromPrompt } } = await deploymentIdPrompt(choices);
-    deploymentId = (depIdFromPrompt as string);
+    const {
+      deployment: {deploymentId: depIdFromPrompt},
+    } = await deploymentIdPrompt(choices);
+    deploymentId = depIdFromPrompt as string;
   }
 
   const deployment = await script.projects.deployments.get({

--- a/src/commands/open.ts
+++ b/src/commands/open.ts
@@ -3,7 +3,7 @@ import open from 'open';
 
 import {loadAPICredentials, script} from '../auth';
 import {ClaspError} from '../clasp-error';
-import {deploymentIdPrompt} from '../inquirer';
+import {deploymentIdPrompt, DeploymentIdPromptChoice} from '../inquirer';
 import {ERROR, LOG} from '../messages';
 import {URL} from '../urls';
 import {ellipsize, getProjectSettings, getWebApplicationURL} from '../utils';
@@ -14,6 +14,14 @@ interface CommandOption {
   readonly addon?: boolean;
   readonly deploymentId?: string;
 }
+
+const getDeploymentId = async (choices: DeploymentIdPromptChoice[]): Promise<string> => {
+  const {
+    deployment: {deploymentId: depIdFromPrompt},
+  } = await deploymentIdPrompt(choices);
+
+  return depIdFromPrompt as string;
+};
 
 /**
  * Opens an Apps Script project's script.google.com editor.
@@ -91,13 +99,7 @@ export default async (scriptId: string, options: CommandOption): Promise<void> =
       };
     });
 
-  let {deploymentId} = options;
-  if (!deploymentId) {
-    const {
-      deployment: {deploymentId: depIdFromPrompt},
-    } = await deploymentIdPrompt(choices);
-    deploymentId = depIdFromPrompt as string;
-  }
+  const deploymentId = options.deploymentId ?? (await getDeploymentId(choices));
 
   const deployment = await script.projects.deployments.get({
     scriptId,

--- a/src/index.ts
+++ b/src/index.ts
@@ -187,6 +187,7 @@ commander
   .option('--webapp', 'Open web application in the browser')
   .option('--creds', 'Open the URL to create credentials')
   .option('--addon', 'List parent IDs and open the URL of the first one')
+  .option('--deploymentId <id>', 'Use custom deployment ID with webapp')
   .action(openCmd);
 
 /**

--- a/src/inquirer.ts
+++ b/src/inquirer.ts
@@ -27,17 +27,17 @@ export const functionNamePrompt = (source: functionNameSource) => {
   return prompt<{functionName: string}>([question]);
 };
 
-interface DeploymentIdPrompt {
+export interface DeploymentIdPromptChoice {
   name: string;
   value: scriptV1.Schema$Deployment;
 }
 
 /**
  * Inquirer prompt for a deployment Id.
- * @param {DeploymentIdPrompt[]} choices An array of `DeploymentIdPrompt` objects.
+ * @param {DeploymentIdChoice[]} choices An array of `DeploymentIdChoice` objects.
  * @returns {Promise<{ deploymentId: string }>} A promise for an object with the `deploymentId` property.
  */
-export const deploymentIdPrompt = (choices: ReadonlyArray<ReadonlyDeep<DeploymentIdPrompt>>) =>
+export const deploymentIdPrompt = (choices: ReadonlyArray<ReadonlyDeep<DeploymentIdPromptChoice>>) =>
   prompt<{deployment: scriptV1.Schema$Deployment}>([
     {
       choices,

--- a/test/commands/open.ts
+++ b/test/commands/open.ts
@@ -30,5 +30,11 @@ describe('Test clasp open function', () => {
     const result = spawnSync(CLASP, ['open', '--addon'], {encoding: 'utf8'});
     expect(result.stdout).to.contain(LOG.OPEN_FIRST_PARENT(PARENT_ID[0]));
   });
+  it('open webapp with deploymentId page correctly', () => {
+    const result = spawnSync(
+      CLASP, ['open', '--webapp', '--deploymentId', 'abcd1234'], {encoding: 'utf8'},
+    );
+    expect(result.stdout).to.not.contain('Open which deployment?');
+  });
   after(cleanup);
 });

--- a/test/commands/open.ts
+++ b/test/commands/open.ts
@@ -31,10 +31,8 @@ describe('Test clasp open function', () => {
     expect(result.stdout).to.contain(LOG.OPEN_FIRST_PARENT(PARENT_ID[0]));
   });
   it('open webapp with deploymentId page correctly', () => {
-    const result = spawnSync(
-      CLASP, ['open', '--webapp', '--deploymentId', 'abcd1234'], {encoding: 'utf8'},
-    );
-    expect(result.stdout).to.not.contain('Open which deployment?');
+    const result = spawnSync(CLASP, ['open', '--webapp', '--deploymentId', 'abcd1234'], {encoding: 'utf8'});
+    expect(result.stdout).to.contain(LOG.OPEN_WEBAPP('abcd1234'));
   });
   after(cleanup);
 });


### PR DESCRIPTION
I would like to propse new `--deploymentID` for `open` command.

**As is**: `open --webapp` prompts user for deployment id
**To be**: `open --webapp --deploymentID abcd1234` opens deployment directly

- [x] `npm run test` succeeds.
- [x] `npm run lint` succeeds.
- [x] Appropriate changes to README are included in PR.
