### PR TITLE
README: Fix Target ES2019 typo

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,7 +65,7 @@ You can also try clasp in Gitpod, a one-click online IDE for GitHub:
 
 - Every ES2019 features (except ES modules)
 - Edit your `appsscript.json` manifest to choose between the **Rhino** and **V8** engines
-- Typescript users should update their `tsconfig.json` with the `"target": "2019"` compiler option
+- Typescript users should update their `tsconfig.json` with the `"target": "ES2019"` compiler option
 
 ## Install
 


### PR DESCRIPTION
Fixes #766

Setting `"target": "2019"` on `tsconfig.json` produces the following error:
> Parsing error: Argument for '--target' option must be: 'es3', 'es5', 'es6', 'es2015', 'es2016', 'es2017', 'es2018', 'es2019', 'es2020', 'esnext'

Updating this documentation to mirror this to "ES2019" correctly produces results. 