### PR TITLE
fix: Exit 1 when `clasp run` failed with an error

### DIFF
--- a/src/commands/run.ts
+++ b/src/commands/run.ts
@@ -79,7 +79,8 @@ const runFunction = async (functionName: string, parameters: string[], scriptId:
     } else if (error?.details) {
       // @see https://developers.google.com/apps-script/api/reference/rest/v1/scripts/run#Status
       const {errorMessage, errorType, scriptStackTraceElements} = error.details[0];
-      console.error(`${chalk.red('Exception:')}`, errorType, errorMessage, scriptStackTraceElements || []);
+      console.error(`${chalk.red('Exception:')}`, errorMessage, scriptStackTraceElements || []);
+      throw new ClaspError(errorType);
     }
   } catch (error) {
     if (error instanceof ClaspError) {


### PR DESCRIPTION
Fixes https://github.com/google/clasp/issues/788

- [ ] `npm run test` succeeds.
- [ ] `npm run lint` succeeds.
- [ ] Appropriate changes to README are included in PR.
