### PR TITLE
fix: commander 6 option clash

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -58,6 +58,7 @@ const manifest = readPkgUp.sync({cwd: require.resolve('.')});
 /**
  * Set global CLI configurations
  */
+commander.storeOptionsAsProperties(false);
 
 /**
  * Displays clasp version


### PR DESCRIPTION
Fixes #<issue_number_goes_here> (it's a good idea to open an issue first for discussion)

- [x] `npm run test` succeeds.
- [x] `npm run lint` succeeds.
- [ ] Appropriate changes to README are included in PR.
