### PR TITLE
fix: exit the process after the command action is performed. Closes #805

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -367,4 +367,6 @@ if (args.length === 0) {
       console.error('Unknown error', error);
     }
   }
+  /* eslint-disable no-process-exit*/
+  process.exit();
 })();


### PR DESCRIPTION
This fixes #805.

I had to disable [this lint rule](https://eslint.org/docs/rules/no-process-exit) which I think does not apply in this particular case. But maybe I am wrong, I am not a JS developer.

- [X] `npm run test` succeeds. (With some errors not introduced by this change)
- [X] `npm run lint` succeeds. (With some errors not introduced by this change)
- [x] Appropriate changes to README are included in PR.
