### PR TITLE
Fix/add readme hyperlink

### DIFF
--- a/README.md
+++ b/README.md
@@ -347,7 +347,7 @@ Lists your most recent Apps Script projects.
 
 ## Advanced Commands
 
-> **NOTE**: These commands require Project ID/credentials setup (see below).
+> **NOTE**: These commands require Project ID/credentials setup ([see below](https://github.com/google/clasp#projectid-optional)).
 
 ### Logs
 

--- a/README.md
+++ b/README.md
@@ -347,7 +347,7 @@ Lists your most recent Apps Script projects.
 
 ## Advanced Commands
 
-> **NOTE**: These commands require Project ID/credentials setup ([see below](https://github.com/google/clasp#projectid-optional)).
+> **NOTE**: These commands require Project ID/credentials setup ([see below](#projectid-optional)).
 
 ### Logs
 


### PR DESCRIPTION
Fixes <https://github.com/google/clasp/issues/792> : Add a hyperlink to the "see below" readme section for setting up Project ID/Credentials.

- [ ] `npm run test` succeeds.
- [x] `npm run lint` succeeds.
- [x] Appropriate changes to README are included in PR.
