### PR TITLE
fix: Don't require package.json for simple commands

### DIFF
--- a/src/files.ts
+++ b/src/files.ts
@@ -4,7 +4,6 @@ import multimatch from 'multimatch';
 import path from 'path';
 import pMap from 'p-map';
 import recursive from 'recursive-readdir';
-import ts2gas from 'ts2gas';
 import typescript from 'typescript';
 
 import {loadAPICredentials, script} from './auth.js';
@@ -41,20 +40,22 @@ interface ProjectFile {
   readonly type: string;
 }
 
-const projectFileWithContent = (file: ProjectFile, transpileOptions: TranspileOptions): ProjectFile => {
-  const source = fs.readFileSync(file.name).toString();
-  const type = getApiFileType(file.name);
+async function transpile(source: string, transpileOptions: TranspileOptions): Promise<string> {
+  const ts2gas = await import('ts2gas');
+  return ts2gas.default(source, transpileOptions);
+}
 
-  return type === 'TS'
-    ? // Transpile TypeScript to Google Apps Script
-      // @see github.com/grant/ts2gas
-      {
-        ...file,
-        source: ts2gas(source, transpileOptions),
-        type: 'SERVER_JS',
-      }
-    : {...file, source, type};
-};
+async function projectFileWithContent(file: ProjectFile, transpileOptions: TranspileOptions): Promise<ProjectFile> {
+  const content = await fs.readFile(file.name);
+  let source = content.toString();
+  let type = getApiFileType(file.name);
+
+  if (type === 'TS') {
+    source = await transpile(source, transpileOptions);
+    type = 'SERVER_JS';
+  }
+  return {...file, source, type};
+}
 
 const ignoredProjectFile = (file: ProjectFile): ProjectFile => ({...file, source: '', isIgnored: true, type: ''});
 
@@ -102,7 +103,8 @@ export const getAllProjectFiles = async (rootDir: string = path.join('.', '/')):
     });
     files.sort((a, b) => a.name.localeCompare(b.name));
 
-    return getContentOfProjectFiles(files).map((file: ProjectFile): ProjectFile => {
+    const filesWithContent = await getContentOfProjectFiles(files);
+    return filesWithContent.map((file: ProjectFile): ProjectFile => {
       // Loop through files that are not ignored from `.claspignore`
       if (!file.isIgnored) {
         // Prevent node_modules/@types/
@@ -142,14 +144,16 @@ export const splitProjectFiles = (files: ProjectFile[]): [ProjectFile[], Project
   files.filter(file => file.isIgnored),
 ];
 
-const getContentOfProjectFiles = (files: ProjectFile[]) => {
+async function getContentOfProjectFiles(files: ProjectFile[]) {
   const transpileOpttions = getTranspileOptions();
 
-  return files.map(file => (file.isIgnored ? file : projectFileWithContent(file, transpileOpttions)));
-};
+  const getContent = (file: ProjectFile) => (file.isIgnored ? file : projectFileWithContent(file, transpileOpttions));
+  return Promise.all(files.map(getContent));
+}
 
-const getAppsScriptFilesFromProjectFiles = (files: ProjectFile[], rootDir: string) =>
-  getContentOfProjectFiles(files).map((file): AppsScriptFile => {
+async function getAppsScriptFilesFromProjectFiles(files: ProjectFile[], rootDir: string) {
+  const filesWithContent = await getContentOfProjectFiles(files);
+  return filesWithContent.map(file => {
     const {name, source, type} = file;
 
     return {
@@ -158,6 +162,7 @@ const getAppsScriptFilesFromProjectFiles = (files: ProjectFile[], rootDir: strin
       type, // The file extension
     };
   });
+}
 
 // This statement customizes the order in which the files are pushed.
 // It puts the files in the setting's filePushOrder first.
@@ -373,7 +378,7 @@ export const pushFiles = async (silent = false) => {
 
     if (toPush.length > 0) {
       const orderedFiles = getOrderedProjectFiles(toPush, filePushOrder);
-      const files = getAppsScriptFilesFromProjectFiles(orderedFiles, rootDir ?? path.join('.', '/'));
+      const files = await getAppsScriptFilesFromProjectFiles(orderedFiles, rootDir ?? path.join('.', '/'));
       const filenames = orderedFiles.map(file => file.name);
 
       // Start pushing.


### PR DESCRIPTION
Moves ts2gas to a dynamic import only when transpiling typescript code.

Fixes #856 