### PR TITLE
Fix test commands build

### DIFF
--- a/test/commands/logout.ts
+++ b/test/commands/logout.ts
@@ -3,9 +3,9 @@ import {spawnSync} from 'child_process';
 import fs from 'fs-extra';
 import {after, before, beforeEach, describe, it} from 'mocha';
 
-import {hasOauthClientSettings} from '../../src/utils';
-import {CLASP, CLASP_PATHS, FAKE_CLASPRC} from '../constants';
-import {backupSettings, cleanup, restoreSettings, setup} from '../functions';
+import {hasOauthClientSettings} from '../../src/utils.js';
+import {CLASP, CLASP_PATHS, FAKE_CLASPRC} from '../constants.js';
+import {backupSettings, cleanup, restoreSettings, setup} from '../functions.js';
 
 describe('Test clasp logout function', () => {
   before(setup);

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -28,6 +28,6 @@
   },
   "include": [
     "src/**.ts",
-    "test/**.ts"
+    "test/**/*.ts"
   ]
 }


### PR DESCRIPTION
Fixes #887

- [ ] `npm run test` succeeds.
Because this PR is just to re-enable non-running tests some tests is failing locally to me. But I guess it's because of permissions on GDrive.
  73 passing 
  26 pending
  16 failing


- [x] `npm run lint` succeeds.
- [x] Appropriate changes to README are included in PR.
