### PR TITLE
Lock lines-and-columns to 1.1.6

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -24,6 +24,7 @@
         "inquirer": "^8.1.2",
         "inquirer-autocomplete-prompt-ipt": "^2.0.0",
         "is-reachable": "^5.0.0",
+        "lines-and-columns": "1.1.6",
         "log-symbols": "^5.0.0",
         "loud-rejection": "^2.2.0",
         "make-dir": "^3.1.0",

--- a/package.json
+++ b/package.json
@@ -89,7 +89,8 @@
     "split-lines": "^3.0.0",
     "strip-bom": "^5.0.0",
     "ts2gas": "^4.2.0",
-    "typescript": "^4.4.2"
+    "typescript": "^4.4.2",
+    "lines-and-columns": "1.1.6"
   },
   "devDependencies": {
     "@types/chai": "^4.2.21",


### PR DESCRIPTION
[lines-and-columns](https://www.npmjs.com/package/lines-and-columns
) published a breaking change (1.1.7) which broke clasp https://github.com/eventualbuddha/lines-and-columns/pull/199 cc: @eventualbuddha

```
Run clasp login --status
  clasp login --status
  shell: /usr/bin/bash -e {0}
internal/modules/cjs/loader.js:929
  const err = new Error(`Cannot find module '${request}'`);
              ^

Error: Cannot find module '/usr/local/lib/node_modules/@google/clasp/node_modules/lines-and-columns/build/index.mjs'
    at createEsmNotFoundErr (internal/modules/cjs/loader.js:929:15)
    at finalizeEsmResolution (internal/modules/cjs/loader.js:922:15)
    at resolveExports (internal/modules/cjs/loader.js:450:14)
    at Function.Module._findPath (internal/modules/cjs/loader.js:490:31)
    at Function.Module._resolveFilename (internal/modules/cjs/loader.js:888:27)
    at Function.Module._load (internal/modules/cjs/loader.js:746:27)
    at Module.require (internal/modules/cjs/loader.js:974:19)
    at require (internal/modules/cjs/helpers.js:93:18)
    at Object.<anonymous> (/usr/local/lib/node_modules/@google/clasp/node_modules/parse-json/index.js:4:36)
    at Module._compile (internal/modules/cjs/loader.js:1085:14) {
  code: 'MODULE_NOT_FOUND',
  path: '/usr/local/lib/node_modules/@google/clasp/node_modules/lines-and-columns/package.json'
```

- [ ] `npm run test` succeeds.
- [ ] `npm run lint` succeeds.
- [ ] Appropriate changes to README are included in PR.
