### PR TITLE
docs: fix typo about treeshaking

### DIFF
--- a/docs/esmodules.md
+++ b/docs/esmodules.md
@@ -12,12 +12,12 @@ import { nodeResolve } from "@rollup/plugin-node-resolve";
 
 const extensions = [".ts", ".js"];
 
-const preventThreeShakingPlugin = () => {
+const preventTreeShakingPlugin = () => {
     return {
-      name: 'no-threeshaking',
+      name: 'no-treeshaking',
       resolveId(id, importer) {
         if (!importer) {
-            // let's not theeshake entry points, as we're not exporting anything in Apps Script files
+            // let's not treeshake entry points, as we're not exporting anything in Apps Script files
           return {id, moduleSideEffects: "no-treeshake" }
         }
         return null;
@@ -32,7 +32,7 @@ export default {
     format: "esm",
   },
   plugins: [
-    preventThreeShakingPlugin(),
+    preventTreeShakingPlugin(),
     nodeResolve({
       extensions,
     }),


### PR DESCRIPTION
- [ ] `npm run test` succeeds.
- [x] `npm run lint` succeeds.
- [ ] Appropriate changes to README are included in PR.

---

three -> tree
thee -> tree