### PR TITLE
- debounce manifest change check

### DIFF
--- a/src/commands/push.ts
+++ b/src/commands/push.ts
@@ -44,6 +44,11 @@ export default async (options: CommandOption): Promise<void> => {
     console.log(LOG.PUSH_WATCH);
     // Debounce calls to push to coalesce 'save all' actions from editors
     const debouncedPushFiles = debounce(async () => {
+      if (!options.force && (await manifestHasChanges(projectSettings)) && !(await confirmManifestUpdate())) {
+        console.log('Stopping push…');
+        return;
+      }
+
       console.log(LOG.PUSHING);
       return pushFiles();
     }, WATCH_DEBOUNCE_MS);
@@ -54,10 +59,6 @@ export default async (options: CommandOption): Promise<void> => {
         return;
       }
       console.log(`\n${LOG.PUSH_WATCH_UPDATED(filePath)}\n`);
-      if (!options.force && (await manifestHasChanges(projectSettings)) && !(await confirmManifestUpdate())) {
-        console.log('Stopping push…');
-        return;
-      }
       return debouncedPushFiles();
     };
     const watcher = chokidar.watch(rootDir, {persistent: true, ignoreInitial: true});


### PR DESCRIPTION
Fixes #<905>: [link](https://github.com/google/clasp/issues/905)
Issue: clasp push --watch will check manifest change per each changed file

- [x] `npm run test` succeeds.
- [x] `npm run lint` succeeds.
- [x] Appropriate changes to README are included in PR (no need)
