### PR TITLE
fix: remove online check

### DIFF
--- a/src/auth.ts
+++ b/src/auth.ts
@@ -12,7 +12,7 @@ import type {ReadonlyDeep} from 'type-fest';
 import {ClaspError} from './clasp-error.js';
 import {DOTFILE} from './dotfile.js';
 import {ERROR, LOG} from './messages.js';
-import {checkIfOnlineOrDie, getOAuthSettings} from './utils.js';
+import {getOAuthSettings} from './utils.js';
 import type {ClaspToken} from './dotfile';
 import type {ClaspCredentials} from './utils';
 
@@ -291,7 +291,6 @@ const setOauthClientCredentials = async (rc: ClaspToken) => {
 
   // Set credentials and refresh them.
   try {
-    await checkIfOnlineOrDie();
     if (rc.isLocalCreds) {
       const {clientId, clientSecret, redirectUri} = rc.oauth2ClientSettings;
       localOAuth2Client = new OAuth2Client({clientId, clientSecret, redirectUri});

--- a/src/commands/apis.ts
+++ b/src/commands/apis.ts
@@ -8,7 +8,7 @@ import {discovery, loadAPICredentials, serviceUsage} from '../auth.js';
 import {ClaspError} from '../clasp-error.js';
 import {ERROR} from '../messages.js';
 import {URL} from '../urls.js';
-import {checkIfOnlineOrDie, getProjectId} from '../utils.js';
+import {getProjectId} from '../utils.js';
 
 type DirectoryItem = Unpacked<discoveryV1.Schema$DirectoryList['items']>;
 type PublicAdvancedService = ReadonlyDeep<Required<NonNullable<DirectoryItem>>>;
@@ -38,7 +38,6 @@ export default async (options: CommandOption): Promise<void> => {
     disable: async () => enableOrDisableAPI(serviceName, false),
     enable: async () => enableOrDisableAPI(serviceName, true),
     list: async () => {
-      await checkIfOnlineOrDie();
       /**
        * List currently enabled APIs.
        */

--- a/src/commands/clone.ts
+++ b/src/commands/clone.ts
@@ -6,7 +6,7 @@ import {fetchProject, hasProject, writeProjectFiles} from '../files.js';
 import {ScriptIdPrompt, scriptIdPrompt} from '../inquirer.js';
 import {ERROR, LOG} from '../messages.js';
 import {extractScriptId} from '../urls.js';
-import {checkIfOnlineOrDie, saveProject, spinner} from '../utils.js';
+import {saveProject, spinner} from '../utils.js';
 import status from './status.js';
 import {Conf} from '../conf.js';
 
@@ -32,7 +32,6 @@ export default async (
   if (options.rootDir) {
     config.projectRootDirectory = options.rootDir;
   }
-  await checkIfOnlineOrDie();
   if (hasProject()) {
     throw new ClaspError(ERROR.FOLDER_EXISTS());
   }

--- a/src/commands/create.ts
+++ b/src/commands/create.ts
@@ -6,13 +6,7 @@ import {fetchProject, hasProject, writeProjectFiles} from '../files.js';
 import {scriptTypePrompt} from '../inquirer.js';
 import {manifestExists} from '../manifest.js';
 import {ERROR, LOG} from '../messages.js';
-import {
-  getDefaultProjectName,
-  getProjectSettings,
-  saveProject,
-  spinner,
-  stopSpinner,
-} from '../utils.js';
+import {getDefaultProjectName, getProjectSettings, saveProject, spinner, stopSpinner} from '../utils.js';
 import {Conf} from '../conf.js';
 
 const config = Conf.get();

--- a/src/commands/create.ts
+++ b/src/commands/create.ts
@@ -7,7 +7,6 @@ import {scriptTypePrompt} from '../inquirer.js';
 import {manifestExists} from '../manifest.js';
 import {ERROR, LOG} from '../messages.js';
 import {
-  checkIfOnlineOrDie,
   getDefaultProjectName,
   getProjectSettings,
   saveProject,
@@ -39,7 +38,6 @@ export default async (options: CommandOption): Promise<void> => {
   }
 
   // Handle common errors.
-  await checkIfOnlineOrDie();
   if (hasProject()) {
     throw new ClaspError(ERROR.FOLDER_EXISTS());
   }

--- a/src/commands/deploy.ts
+++ b/src/commands/deploy.ts
@@ -2,7 +2,7 @@ import {loadAPICredentials, script} from '../auth.js';
 import {ClaspError} from '../clasp-error.js';
 import {PROJECT_MANIFEST_BASENAME as manifestFileName} from '../constants.js';
 import {ERROR, LOG} from '../messages.js';
-import {checkIfOnlineOrDie, getProjectSettings, spinner, stopSpinner} from '../utils.js';
+import {getProjectSettings, spinner, stopSpinner} from '../utils.js';
 
 interface CommandOption {
   readonly versionNumber?: number;
@@ -17,7 +17,6 @@ interface CommandOption {
  * @param options.deploymentId  {string} The deployment ID to redeploy.
  */
 export default async (options: CommandOption): Promise<void> => {
-  await checkIfOnlineOrDie();
   await loadAPICredentials();
   const {scriptId} = await getProjectSettings();
   if (!scriptId) {

--- a/src/commands/deployments.ts
+++ b/src/commands/deployments.ts
@@ -1,13 +1,12 @@
 import {loadAPICredentials, script} from '../auth.js';
 import {ClaspError} from '../clasp-error.js';
 import {LOG} from '../messages.js';
-import {checkIfOnlineOrDie, getProjectSettings, spinner, stopSpinner} from '../utils.js';
+import {getProjectSettings, spinner, stopSpinner} from '../utils.js';
 
 /**
  * Lists a script's deployments.
  */
 export default async (): Promise<void> => {
-  await checkIfOnlineOrDie();
   await loadAPICredentials();
   const {scriptId} = await getProjectSettings();
   if (scriptId) {

--- a/src/commands/list.ts
+++ b/src/commands/list.ts
@@ -2,7 +2,7 @@ import {drive, loadAPICredentials} from '../auth.js';
 import {ClaspError} from '../clasp-error.js';
 import {ERROR, LOG} from '../messages.js';
 import {URL} from '../urls.js';
-import {checkIfOnlineOrDie, ellipsize, spinner, stopSpinner} from '../utils.js';
+import {ellipsize, spinner, stopSpinner} from '../utils.js';
 
 interface CommandOption {
   readonly noShorten: boolean;
@@ -13,7 +13,6 @@ interface CommandOption {
  * @param options.noShorten {boolean}
  */
 export default async (options: CommandOption): Promise<void> => {
-  await checkIfOnlineOrDie();
   await loadAPICredentials();
 
   spinner.start(LOG.FINDING_SCRIPTS);

--- a/src/commands/login.ts
+++ b/src/commands/login.ts
@@ -8,7 +8,7 @@ import {authorize, defaultScopes, getLoggedInEmail, scopeWebAppDeploy} from '../
 import {FS_OPTIONS} from '../constants.js';
 import {readManifest} from '../manifest.js';
 import {ERROR, LOG} from '../messages.js';
-import {checkIfOnlineOrDie, hasOauthClientSettings, safeIsOnline} from '../utils.js';
+import {hasOauthClientSettings, safeIsOnline} from '../utils.js';
 import type {ClaspCredentials} from '../utils.js';
 
 const {readJsonSync} = fs;
@@ -49,8 +49,6 @@ export default async (options: CommandOption): Promise<void> => {
   }
 
   console.log(LOG.LOGIN(isLocalLogin));
-  await checkIfOnlineOrDie();
-
   // Localhost check
   const useLocalhost = Boolean(options.localhost);
 

--- a/src/commands/logs.ts
+++ b/src/commands/logs.ts
@@ -9,13 +9,7 @@ import {DOTFILE, ProjectSettings} from '../dotfile.js';
 import {projectIdPrompt} from '../inquirer.js';
 import {ERROR, LOG} from '../messages.js';
 import {URL} from '../urls.js';
-import {
-  getErrorMessage,
-  getProjectSettings,
-  isValidProjectId,
-  spinner,
-  stopSpinner,
-} from '../utils.js';
+import {getErrorMessage, getProjectSettings, isValidProjectId, spinner, stopSpinner} from '../utils.js';
 
 interface CommandOption {
   readonly json?: boolean;

--- a/src/commands/logs.ts
+++ b/src/commands/logs.ts
@@ -10,7 +10,6 @@ import {projectIdPrompt} from '../inquirer.js';
 import {ERROR, LOG} from '../messages.js';
 import {URL} from '../urls.js';
 import {
-  checkIfOnlineOrDie,
   getErrorMessage,
   getProjectSettings,
   isValidProjectId,
@@ -35,7 +34,6 @@ interface CommandOption {
  * @param options.simplified {boolean} If true, the command will remove timestamps from the logs.
  */
 export default async (options: CommandOption): Promise<void> => {
-  await checkIfOnlineOrDie();
   // Get project settings.
   const projectSettings = await getProjectSettings();
   let projectId = options.setup ? await setupLogs(projectSettings) : projectSettings.projectId;

--- a/src/commands/pull.ts
+++ b/src/commands/pull.ts
@@ -1,6 +1,6 @@
 import {fetchProject, writeProjectFiles} from '../files.js';
 import {LOG} from '../messages.js';
-import {checkIfOnlineOrDie, getProjectSettings, spinner, stopSpinner} from '../utils.js';
+import {getProjectSettings, spinner, stopSpinner} from '../utils.js';
 
 interface CommandOption {
   readonly versionNumber?: number;
@@ -12,7 +12,6 @@ interface CommandOption {
  *                              If not provided, the project's HEAD version is returned.
  */
 export default async (options: CommandOption): Promise<void> => {
-  await checkIfOnlineOrDie();
   const {scriptId, rootDir} = await getProjectSettings();
   if (scriptId) {
     spinner.start(LOG.PULLING);

--- a/src/commands/push.ts
+++ b/src/commands/push.ts
@@ -13,7 +13,7 @@ import {fetchProject, pushFiles} from '../files.js';
 import {overwritePrompt} from '../inquirer.js';
 import {isValidManifest} from '../manifest.js';
 import {LOG} from '../messages.js';
-import {checkIfOnlineOrDie, getProjectSettings, spinner} from '../utils.js';
+import {getProjectSettings, spinner} from '../utils.js';
 
 import type {ProjectSettings} from '../dotfile';
 
@@ -34,7 +34,6 @@ interface CommandOption {
  * @param options.watch {boolean} If true, runs `clasp push` when any local file changes. Exit with ^C.
  */
 export default async (options: CommandOption): Promise<void> => {
-  await checkIfOnlineOrDie();
   await loadAPICredentials();
   await isValidManifest();
   const projectSettings = await getProjectSettings();

--- a/src/commands/run.ts
+++ b/src/commands/run.ts
@@ -7,7 +7,7 @@ import {ClaspError} from '../clasp-error.js';
 import {addScopeToManifest, isValidRunManifest} from '../manifest.js';
 import {ERROR} from '../messages.js';
 import {URL} from '../urls.js';
-import {checkIfOnlineOrDie, getProjectSettings, parseJsonOrDie, spinner, stopSpinner} from '../utils.js';
+import {getProjectSettings, parseJsonOrDie, spinner, stopSpinner} from '../utils.js';
 
 interface CommandOption {
   readonly nondev: boolean;
@@ -23,7 +23,6 @@ interface CommandOption {
  * @requires `clasp login --creds` to be run beforehand.
  */
 export default async (functionName: string, options: CommandOption): Promise<void> => {
-  await checkIfOnlineOrDie();
   await loadAPICredentials();
   const {scriptId} = await getProjectSettings();
   const devMode = !options.nondev; // Defaults to true

--- a/src/commands/status.ts
+++ b/src/commands/status.ts
@@ -1,6 +1,6 @@
 import {getAllProjectFiles, getOrderedProjectFiles, logFileList, splitProjectFiles} from '../files.js';
 import {LOG} from '../messages.js';
-import {checkIfOnlineOrDie, getProjectSettings} from '../utils.js';
+import {getProjectSettings} from '../utils.js';
 
 interface CommandOption {
   readonly json?: boolean;
@@ -11,7 +11,6 @@ interface CommandOption {
  * @param options.json {boolean} Displays the status in json format.
  */
 export default async ({json}: CommandOption = {json: false}): Promise<void> => {
-  await checkIfOnlineOrDie();
   const {filePushOrder, scriptId, rootDir} = await getProjectSettings();
   if (scriptId) {
     const [toPush, toIgnore] = splitProjectFiles(await getAllProjectFiles(rootDir));

--- a/src/commands/undeploy.ts
+++ b/src/commands/undeploy.ts
@@ -4,7 +4,7 @@ import pMap from 'p-map';
 import {loadAPICredentials, script} from '../auth.js';
 import {ClaspError} from '../clasp-error.js';
 import {ERROR, LOG} from '../messages.js';
-import {checkIfOnlineOrDie, getProjectSettings, spinner, stopSpinner} from '../utils.js';
+import {getProjectSettings, spinner, stopSpinner} from '../utils.js';
 
 interface CommandOption {
   readonly all?: boolean;
@@ -15,7 +15,6 @@ interface CommandOption {
  * @param deploymentId {string} The deployment's ID
  */
 export default async (deploymentId: string | undefined, options: CommandOption): Promise<void> => {
-  await checkIfOnlineOrDie();
   await loadAPICredentials();
   const {scriptId} = await getProjectSettings();
   if (scriptId) {

--- a/src/commands/version.ts
+++ b/src/commands/version.ts
@@ -2,13 +2,12 @@ import {loadAPICredentials, script} from '../auth.js';
 import {ClaspError} from '../clasp-error.js';
 import {descriptionPrompt} from '../inquirer.js';
 import {LOG} from '../messages.js';
-import {checkIfOnlineOrDie, getProjectSettings, spinner, stopSpinner} from '../utils.js';
+import {getProjectSettings, spinner, stopSpinner} from '../utils.js';
 
 /**
  * Creates a new version of an Apps Script project.
  */
 export default async (description?: string): Promise<void> => {
-  await checkIfOnlineOrDie();
   await loadAPICredentials();
 
   const {scriptId} = await getProjectSettings();

--- a/src/commands/versions.ts
+++ b/src/commands/versions.ts
@@ -3,13 +3,12 @@ import {script_v1 as scriptV1} from 'googleapis';
 import {loadAPICredentials, script} from '../auth.js';
 import {ClaspError} from '../clasp-error.js';
 import {LOG} from '../messages.js';
-import {checkIfOnlineOrDie, getProjectSettings, spinner, stopSpinner} from '../utils.js';
+import {getProjectSettings, spinner, stopSpinner} from '../utils.js';
 
 /**
  * Lists versions of an Apps Script project.
  */
 export default async (): Promise<void> => {
-  await checkIfOnlineOrDie();
   await loadAPICredentials();
 
   spinner.start('Grabbing versions…');

--- a/src/files.ts
+++ b/src/files.ts
@@ -12,13 +12,7 @@ import {Conf} from './conf.js';
 import {FS_OPTIONS, PROJECT_MANIFEST_FILENAME} from './constants.js';
 import {DOTFILE} from './dotfile.js';
 import {ERROR, LOG} from './messages.js';
-import {
-  getApiFileType,
-  getErrorMessage,
-  getProjectSettings,
-  spinner,
-  stopSpinner,
-} from './utils.js';
+import {getApiFileType, getErrorMessage, getProjectSettings, spinner, stopSpinner} from './utils.js';
 
 import type {TranspileOptions} from 'typescript';
 

--- a/src/files.ts
+++ b/src/files.ts
@@ -13,7 +13,6 @@ import {FS_OPTIONS, PROJECT_MANIFEST_FILENAME} from './constants.js';
 import {DOTFILE} from './dotfile.js';
 import {ERROR, LOG} from './messages.js';
 import {
-  checkIfOnlineOrDie,
   getApiFileType,
   getErrorMessage,
   getProjectSettings,
@@ -300,7 +299,6 @@ export const fetchProject = async (
   versionNumber?: number,
   silent = false
 ): Promise<AppsScriptFile[]> => {
-  await checkIfOnlineOrDie();
   await loadAPICredentials();
   spinner.start();
   let response;


### PR DESCRIPTION
Removes online check. I believe this was added from a user's PR from long ago, but it has caused many user errors over the years. The CLI shouldn't even special case to check if the client is online, the client should just directly try. The [implementation](https://github.com/google/clasp/blob/aa4197c00193e83b71f4b696e67730bbb48fdaf9/src/utils.ts#L186-L226) is kind of scary when you look at it (not attempted to change / remove).

Fixes https://github.com/google/clasp/issues/872
Fixes https://github.com/google/clasp/issues/934
Fixes https://github.com/google/clasp/issues/886
Fixes https://github.com/google/clasp/issues/913
Fixes https://github.com/google/clasp/issues/909
Fixes https://github.com/google/clasp/issues/930

- [x] `npm run test` succeeds.
- [x] `npm run lint` succeeds.
- [x] Appropriate changes to README are included in PR.

R=@sqrrrl 