### PR TITLE
Fix typo in README: "They" -> "The"

### DIFF
--- a/README.md
+++ b/README.md
@@ -447,7 +447,7 @@ If `newValue` is omitted it returns the current setting value.
 
 #### Options
 
-- `settingKey`: settingKey They key in `.clasp.json` you want to change
+- `settingKey`: settingKey The key in `.clasp.json` you want to change
 - `newValue`: newValue The new value for the setting
 
 #### Examples


### PR DESCRIPTION
- [ ] `npm run test` succeeds.
- [ ] `npm run lint` succeeds.
- [x] Appropriate changes to README are included in PR.
