### PR TITLE
Update run.md to use Desktop App for OAuth Client ID Application Type 

### DIFF
--- a/docs/run.md
+++ b/docs/run.md
@@ -7,7 +7,7 @@
 To use `clasp run`, you need to complete 4 steps:
 
 - Set up a **Project ID**.
-- Create an **OAuth Client ID** (Other). Download as `creds.json`.
+- Create an **OAuth Client ID** (Desktop App). Download as `creds.json`.
 - `clasp login --creds creds.json` with this downloaded file.
 - Add the following to `appsscript.json`:
   ```json


### PR DESCRIPTION
The "Other" application type has been deprecated and is no longer available. The recommended application type to use for clasp run is now Desktop app.

Fixes #997
