### PR TITLE
Fix: Update remote path normalization (Windows compatibility)

### DIFF
--- a/src/core/files.ts
+++ b/src/core/files.ts
@@ -191,7 +191,7 @@ export class Files {
         const localPath = path.relative(process.cwd(), path.join(contentDir, filename));
         const resolvedPath = path.relative(contentDir, localPath);
         const parsedPath = path.parse(resolvedPath);
-        let remotePath = path.format({dir: normalizePath(parsedPath.dir), name: parsedPath.name});
+        let remotePath = normalizePath(path.format({ dir: parsedPath.dir, name: parsedPath.name }));
 
         const type = getFileType(localPath, fileExtensionMap);
         if (!type) {

--- a/test/core/files.ts
+++ b/test/core/files.ts
@@ -39,6 +39,7 @@ describe('File operations', function () {
         'appsscript.json': mockfs.load(path.resolve(__dirname, '../fixtures/appsscript-no-services.json')),
         'Code.js': mockfs.load(path.resolve(__dirname, '../fixtures/Code.js')),
         'subdir/Code.js': mockfs.load(path.resolve(__dirname, '../fixtures/Code.js')),
+        'subdir/subdir/Code.js': mockfs.load(path.resolve(__dirname, '../fixtures/Code.js')),
         'page.html': mockfs.load(path.resolve(__dirname, '../fixtures/page.html')),
         '.clasp.json': mockfs.load(path.resolve(__dirname, '../fixtures/dot-clasp-no-settings.json')),
         'package.json': '{}',
@@ -54,7 +55,7 @@ describe('File operations', function () {
         credentials: mockCredentials(),
       });
       const foundFiles = await clasp.files.collectLocalFiles();
-      expect(foundFiles).to.have.length(4);
+      expect(foundFiles).to.have.length(5);
     });
 
     it('should push files', async function () {


### PR DESCRIPTION
This PR fixes a compatibility issue on Windows where remote path normalization did not work correctly.
Specifically, paths containing backslashes (\) were not normalized properly, causing issues when syncing files.

- [ ] `npm run test` succeeds.
- [ ] `npm run lint` succeeds.
- [ ] Appropriate changes to README are included in PR.
