### PR TITLE
Fix: Normalize file paths in file operations for Windows compatibility

### DIFF
--- a/src/core/files.ts
+++ b/src/core/files.ts
@@ -197,7 +197,7 @@ export class Files {
         const localPath = path.relative(process.cwd(), path.join(contentDir, filename));
         const resolvedPath = path.relative(contentDir, localPath);
         const parsedPath = path.parse(resolvedPath);
-        let remotePath = path.format({dir: normalizePath(parsedPath.dir), name: parsedPath.name});
+        let remotePath = normalizePath(path.format({dir: parsedPath.dir, name: parsedPath.name}));
 
         const type = getFileType(localPath, fileExtensionMap);
         if (!type) {
@@ -293,7 +293,7 @@ export class Files {
         if (dirsWithIncludedFiles.has(dir)) {
           break;
         }
-        excludedPath = `${dir}/`;
+        excludedPath = path.normalize(`${dir}/`);
       }
       debug('Found untracked file %s', excludedPath);
       untrackedFiles.add(excludedPath);

--- a/test/core/files.ts
+++ b/test/core/files.ts
@@ -372,8 +372,8 @@ describe('File operations', function () {
       });
       const pulledFiles = await clasp.files.pull();
       expect(pulledFiles).to.have.length(2);
-      expect(pulledFiles[0].localPath).to.equal('dist/appsscript.json');
-      expect(pulledFiles[1].localPath).to.equal('dist/Code.js');
+      expect(pulledFiles[0].localPath).to.equal(path.normalize('dist/appsscript.json'));
+      expect(pulledFiles[1].localPath).to.equal(path.normalize('dist/Code.js'));
     });
 
     afterEach(function () {
@@ -450,10 +450,10 @@ describe('File operations', function () {
         credentials: mockCredentials(),
       });
       const foundFiles = await clasp.files.getUntrackedFiles();
-      expect(foundFiles).to.include('node_modules/');
-      expect(foundFiles).to.not.include('node_modules/test/');
-      expect(foundFiles).to.not.include('node_modules/test/file1.js');
-      expect(foundFiles).to.include('src/readme.md');
+      expect(foundFiles).to.include(path.normalize('node_modules/'));
+      expect(foundFiles).to.not.include(path.normalize('node_modules/test/'));
+      expect(foundFiles).to.not.include(path.normalize('node_modules/test/file1.js'));
+      expect(foundFiles).to.include(path.normalize('src/readme.md'));
     });
   });
 


### PR DESCRIPTION
Fixes # (no related issue)

- [x] `npm run test` succeeds.
- [x] `npm run lint` succeeds.
- [ ] Appropriate changes to README are included in PR. (N/A)

## Summary
This PR fixes file path normalization in file operations to ensure compatibility with Windows environments. 

## Details
- Corrected path normalization logic to handle Windows-specific file paths.
- Updated test cases to verify correct path normalization on Windows.

## Testing
All tests and lint checks were executed successfully on a Windows environment.
