### PR TITLE
fix: handle unknown severity levels in logs

### DIFF
--- a/src/commands/tail-logs.ts
+++ b/src/commands/tail-logs.ts
@@ -135,7 +135,8 @@ function formatEntry(entry: loggingV2.Schema$LogEntry, options: FormatOptions): 
     }
   }
 
-  const coloredSeverity = `${severityColor[severity!](severity) || severity!}`.padEnd(20);
+  const colorizer = severityColor[severity!];
+  const coloredSeverity = `${colorizer ? colorizer(severity!) : severity!}`.padEnd(20);
 
   functionName = functionName.padEnd(15);
   payloadData = payloadData.padEnd(20);

--- a/test/commands/open-container.ts
+++ b/test/commands/open-container.ts
@@ -47,7 +47,7 @@ describe('Open container command', function () {
           path.resolve(__dirname, '../fixtures/dot-clasprc-authenticated.json'),
         ),
       });
-    });;
+    });
 
     it('should open the container as json', async function () {
       const out = await runCommand(['open-container', '--json']);

--- a/test/commands/update-deployment.ts
+++ b/test/commands/update-deployment.ts
@@ -21,12 +21,7 @@ import {expect} from 'chai';
 import {afterEach, beforeEach, describe, it} from 'mocha';
 import mockfs from 'mock-fs';
 import {useChaiExtensions} from '../helpers.js';
-import {
-  mockOAuthRefreshRequest,
-  mockUpdateDeployment,
-  resetMocks,
-  setupMocks,
-} from '../mocks.js';
+import {mockOAuthRefreshRequest, mockUpdateDeployment, resetMocks, setupMocks} from '../mocks.js';
 import {runCommand} from './utils.js';
 
 useChaiExtensions();


### PR DESCRIPTION
The 'clasp logs' command would previously crash with a 'severityColor[severity] is not a function' error if a log entry had a an unknown severity level.

This commit fixes the issue by checking if the severity level exists in the severityColor map before attempting to use it as a function. If the severity level is not found, it defaults to using the raw severity string, preventing the crash and making the logging more robust.
