### PR TITLE
Feat: Add config file to make repo a Gemini CLI extension

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,6 +66,16 @@ Then enable the Google Apps Script API: https://script.google.com/home/usersetti
 
 ![Enable Apps Script API](https://user-images.githubusercontent.com/744973/54870967-a9135780-4d6a-11e9-991c-9f57a508bdf0.gif)
 
+### Installing as a Gemini CLI Extension
+
+You can install clasp as an Gemini CLI extensions using the following command:
+
+`gemini extensions install https://github.com/google/clasp`
+
+This makes clasp available as an MCP server in Gemini CLI. 
+
+Make sure to enable the Google Apps Script API (as explained above) and perform a `clasp login` (with your specific login parameters) before you use the extension.
+
 ## Commands
 
 The following command provide basic Apps Script project management.

--- a/gemini-extension.json
+++ b/gemini-extension.json
@@ -1,0 +1,14 @@
+{
+	"name": "clasp",
+	"version": "latest",
+	"mcpServers": {
+        "clasp": {
+        "command": "clasp",
+        "args": ["mcp"],
+        "env": {},
+        "cwd": "./",
+        "timeout": 30000,
+        "trust": true
+        }
+  }
+}


### PR DESCRIPTION
Adds the option to install clasp as a Gemini CLI extension

- [x] `npm run test` succeeds.
- [x] `npm run lint` succeeds.
- [x] Appropriate changes to README are included in PR.
