### PR TITLE
Update auth.ts

### DIFF
--- a/src/auth/auth.ts
+++ b/src/auth/auth.ts
@@ -226,7 +226,7 @@ async function saveOauthClientCredentials(store: CredentialStore, userKey: strin
 }
 
 /**
- * Creates an aunthorized oauth2 client with the given credentials
+ * Creates an authorized OAuth2 client with the given credentials
  * @param clientSecretPath
  * @returns
  */


### PR DESCRIPTION
Throw error in the case the user-provided credentials file does not include keys "installed" or "web" to prevent unclear "Cannot read properties of undefined (reading 'redirect_uris')" error. https://github.com/google/clasp/issues/950#issuecomment-2715462870 no longer seems to be accurate, since the code does not seem to allow for service account JSON key files.

Amends #950 partially (makes error more clear)

- [x] `npm run test` succeeds.
- [x] `npm run lint` succeeds.
- [x] Appropriate changes to README are included in PR.
