### PR TITLE
Make clasp available on Claude code cli as MCP / plugin

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,0 +1,11 @@
+{
+  "name": "clasp",
+  "version": "1.0.0",
+  "description": "Develop Apps Script projects locally using clasp",
+  "mcpServers": {
+    "clasp": {
+      "command": "npx",
+      "args": ["-y", "@google/clasp", "mcp"]
+    }
+  }
+}

--- a/README.md
+++ b/README.md
@@ -78,6 +78,32 @@ This makes clasp available as an MCP server in Gemini CLI.
 
 Make sure to enable the Google Apps Script API (as explained above) and perform a `clasp login` (with your specific login parameters) before you use the extension.
 
+### Installing as a Claude Code CLI Extension
+
+You can use clasp with Claude Code CLI in one of two ways:
+
+#### 1. Install as a Plugin (Recommended)
+
+Run the following command in Claude Code to install clasp as a plugin directly from the repository:
+
+```sh
+/plugin install @google/clasp
+```
+
+#### 2. Manual Installation
+
+You can manually add clasp as an MCP server using the provided configuration file or by running:
+
+```sh
+claude mcp add clasp -- npx -y @google/clasp mcp
+```
+
+Or by referencing the configuration file included in the repository:
+
+```sh
+claude mcp add-json clasp "$(cat claude-mcp.json)"
+```
+
 ## Commands
 
 The following command provide basic Apps Script project management.

--- a/claude-mcp.json
+++ b/claude-mcp.json
@@ -1,0 +1,8 @@
+{
+  "mcpServers": {
+    "clasp": {
+      "command": "npx",
+      "args": ["-y", "@google/clasp", "mcp"]
+    }
+  }
+}


### PR DESCRIPTION
Fixes #1110 
- [x] `npm run test` succeeds.
- [x] `npm run lint` succeeds.
- [x] Appropriate changes to README are included in PR.
