### PR TITLE
Fix typo in command description for list-scripts

### DIFF
--- a/src/commands/list-scripts.ts
+++ b/src/commands/list-scripts.ts
@@ -26,7 +26,7 @@ interface CommandOptions extends GlobalOptions {
 
 export const command = new Command('list-scripts')
   .alias('list')
-  .description('List App Scripts projects')
+  .description('List Apps Script projects')
   .option('--noShorten', 'Do not shorten long names', false)
   .action(async function (this: Command): Promise<void> {
     const options: CommandOptions = this.optsWithGlobals();


### PR DESCRIPTION
This PR corrects the product name in the `list-scripts` command description.
Changed "App Scripts" to "Apps Script" to align with the official branding.

- [x] `npm run test` succeeds.
- [x] `npm run lint` succeeds.
- [ ] Appropriate changes to README are included in PR.
