### PR TITLE
feat: support explicit project, clasp, and extra login scopes

### DIFF
--- a/README.md
+++ b/README.md
@@ -114,7 +114,7 @@ The following command provide basic Apps Script project management.
 clasp
 ```
 
-- [`clasp login [--no-localhost] [--creds <file>] [--redirect-port]`](#login)
+- [`clasp login [--no-localhost] [--creds <file>] [--use-project-scopes] [--include-clasp-scopes] [--extra-scopes <scopes>] [--redirect-port]`](#login)
 - [`clasp logout`](#logout)
 - [`clasp show-authorized-user [--json]`](#show-authorized-user)
 - [`clasp create-script [--title <title>] [--type <type>] [--rootDir <dir>] [--parentId <id>]`](#create)
@@ -136,6 +136,7 @@ clasp
 > **NOTE**: These commands require you to add your [Project ID](#projectid-optional).
 
 - [`clasp tail-logs [--json] [--watch] [--simplified]`](#logs)
+- [`clasp setup-logs [--json]`](#setup-logs)
 - [`clasp list-apis`](#apis)
 - [`clasp enable-api<api>`](#apis)
 - [`clasp disable-api <api>`](#apis)
@@ -365,6 +366,9 @@ Logs the user in. Saves the client credentials to a `.clasprc.json` file in the 
 
 - `--no-localhost`: Do not run a local server, manually enter code instead.
 - `--creds <file>`: Use custom credentials used for `clasp run`. Saves a `.clasprc.json` file to current working directory. This file should be private!
+- `--use-project-scopes`: Use scopes from `appsscript.json` instead of default clasp scopes. Useful for `clasp run` when your script requires runtime scopes.
+- `--include-clasp-scopes`: Include default clasp scopes in addition to project scopes from `appsscript.json`. Can only be used with `--use-project-scopes`.
+- `--extra-scopes <scopes>`: Include additional OAuth scopes as a comma-separated list (for example, `scopeA,scopeB`). Empty entries are rejected.
 - `--redirect-port <port>`: Specify a custom port for the local redirect server during the login process. Useful for environments where a specific port is required.
 
 #### Examples
@@ -372,6 +376,9 @@ Logs the user in. Saves the client credentials to a `.clasprc.json` file in the 
 - `clasp login`
 - `clasp login --no-localhost`
 - `clasp login --user test-user --creds client_secret.json`
+- `clasp login --user test-user --use-project-scopes --creds client_secret.json`
+- `clasp login --user test-user --use-project-scopes --include-clasp-scopes --creds client_secret.json`
+- `clasp login --user test-user --extra-scopes https://www.googleapis.com/auth/spreadsheets.readonly,https://www.googleapis.com/auth/drive.readonly --creds client_secret.json`
 - `clasp login --redirect-port 37473`
 
 ### Logout
@@ -638,6 +645,19 @@ N/A
 ## Advanced Commands
 
 > **NOTE**: These commands require Project ID/credentials setup ([see below](#projectid-optional)).
+
+### Setup Logs
+
+Ensures your script is configured with a GCP project ID, which is required to view logs in Cloud Logging with `clasp logs`.
+
+#### Options
+
+- `--json`: Output result in json format.
+
+#### Examples
+
+- `clasp setup-logs`
+- `clasp setup-logs --json`
 
 ### Logs
 

--- a/docs/run.md
+++ b/docs/run.md
@@ -46,6 +46,9 @@ To use `clasp run`, you need to complete 5 steps:
     - Download the file (⬇), move it to your directory, and name it `client_secret.json`. Please keep this file secret!
 1. Ensure that the [scopes required to run the script are listed in `appsscript.json`](https://developers.google.com/apps-script/concepts/scopes#set-explicit).
 1. Call `clasp login --user <name> --use-project-scopes --creds client_secret.json`
+    - This authorizes the scopes declared in `appsscript.json`.
+    - If needed, include default clasp scopes with `--include-clasp-scopes`.
+    - If needed, add custom scopes with `--extra-scopes <scopeA,scopeB>`.
 1. Add the following to `appsscript.json`:
       ```json
       "executionApi": {
@@ -82,5 +85,6 @@ To run functions that use these scopes, you must add the scopes to your Apps Scr
 - `clasp open-script`
 - `File > Project Properties > Scopes`
 - Add these [scopes to your `appsscript.json`](https://developers.google.com/apps-script/concepts/scopes#set-explicit).
-- Log in again: `clasp login --user <name> --use-project-scopes --creds creds.json`. This will add these scopes to your credentials.
+- Log in again: `clasp login --user <name> --use-project-scopes --include-clasp-scopes --creds creds.json`. This combines your manifest scopes with default clasp scopes in one credential profile.
+- For additional one-off OAuth scopes, include `--extra-scopes` as a comma-separated list with no empty values.
 - `clasp run --user <name> sendMail`


### PR DESCRIPTION
## Problem
`clasp login --use-project-scopes` replaces default clasp scopes with `appsscript.json` scopes.
That forced users to choose between:
1. clasp management scopes (projects/deployments/logging/etc.)
2. runtime project scopes (Drive/Sheets/Gmail/etc.)

Many real workflows need both in one credential profile, so we should be able to support that.

## Summary
Add explicit login scope composition controls so users can choose project scopes, optionally include default clasp scopes, and append explicit extra scopes.

## Maintainer Feedback Addressed
Combined scope authorization is now opt-in.

## What changed
- `--use-project-scopes` now uses manifest scopes (project-only mode).
- Added `--include-clasp-scopes` to explicitly include default clasp scopes with project scopes.
- Kept `--extra-scopes <comma-separated>` as explicit additive scopes.
- Added validation: `--include-clasp-scopes` requires `--use-project-scopes`.
- Scope output reflects the final resolved set when scope-extending flags are used.
- Updated README and run docs to reflect the new options and examples.
- Added tests for scope composition and invalid option combinations.

## Behavior
- `clasp login` -> default clasp scopes.
- `clasp login --use-project-scopes` -> manifest scopes.
- `clasp login --use-project-scopes --include-clasp-scopes` -> manifest + default clasp scopes.
- `--extra-scopes` appends user-provided scopes to whichever base set is selected.

## Testing
- [x] `npm run compile`
- [x] `npm test -- test/commands/login.ts`
