### PR TITLE
feat(push): add timestamp to push success message (#896)

### DIFF
--- a/src/commands/push.ts
+++ b/src/commands/push.ts
@@ -65,7 +65,8 @@ export const command = new Command('push')
       const files = await withSpinner(spinnerMsg, async () => {
         return clasp.files.push();
       });
-
+      //Generate localised timestamp for the output
+      const timestamp = new Date().toLocaleTimeString();
       if (options.json) {
         console.log(
           JSON.stringify(
@@ -81,12 +82,13 @@ export const command = new Command('push')
       const successMessage = intl.formatMessage(
         {
           defaultMessage: `Pushed {count, plural, 
-        =0 {no files.}
-        one {one file.}
-        other {# files}}.`,
+        =0 {no files}
+        one {one file}
+        other {# files}} at {time}.`,
         },
         {
           count: files.length,
+          time: timestamp,
         },
       );
       console.log(successMessage);

--- a/test/commands/push.ts
+++ b/test/commands/push.ts
@@ -76,7 +76,7 @@ describe('Push command', function () {
         scriptId: 'mock-script-id',
       });
       const out = await runCommand(['push']);
-      expect(out.stdout).to.contain('Pushed 2 files');
+      expect(out.stdout).to.match(/Pushed 2 files at .+/);
     });
 
     it('should push files from the rootDir if changed', async function () {
@@ -102,7 +102,7 @@ describe('Push command', function () {
         scriptId: 'mock-script-id',
       });
       const out = await runCommand(['push']);
-      expect(out.stdout).to.contain('Pushed 2 files');
+      expect(out.stdout).to.match(/Pushed 2 files at .+/);
     });
 
     it('should handle manifest update prompt', async function () {
@@ -130,7 +130,7 @@ describe('Push command', function () {
       });
       sinon.stub(inquirer, 'prompt').resolves({overwrite: true});
       const out = await runCommand(['push']);
-      expect(out.stdout).to.contain('Pushed 2 files');
+      expect(out.stdout).to.match(/Pushed 2 files at .+/);
     });
 
     it('should skip push on manifest update reject', async function () {
@@ -159,7 +159,7 @@ describe('Push command', function () {
       sinon.stub(inquirer, 'prompt').resolves({overwrite: false});
       const out = await runCommand(['push']);
       expect(out.stdout).to.contain('Skipping push');
-      expect(out.stdout).to.not.contain('Pushed 2 files');
+      expect(out.stdout).to.not.match(/Pushed 2 files at .+/);
     });
 
     it('should push files as json', async function () {


### PR DESCRIPTION
Fixes #896

- [x] `npm run test` succeeds.
- [x] `npm run lint` succeeds.
- [x] Appropriate changes to README are included in PR. *(Note: Checked the README and no changes were necessary).*

### What changed?
This PR adds a localised execution timestamp to the success message of the `clasp push` command.

Previously, users would see:
`Pushed 2 files.`

Now, users will see:
`Pushed 2 files at 15:13:21.` (Time format respects the users's local system settings via `toLocaleTimeString()`).