### PR TITLE
Fix Path Traversal Vulnerability in pull command via .clasp.json srcDir

### DIFF
--- a/src/core/clasp.ts
+++ b/src/core/clasp.ts
@@ -25,7 +25,7 @@ import JSON5 from 'json5';
 import splitLines from 'split-lines';
 import stripBom from 'strip-bom';
 import {getUserInfo} from '../auth/auth.js';
-import {Files} from './files.js';
+import {Files, isInside} from './files.js';
 import {Functions} from './functions.js';
 import {Logs} from './logs.js';
 import {Project} from './project.js';
@@ -129,6 +129,13 @@ export class Clasp {
     if (!path.isAbsolute(contentDir)) {
       contentDir = path.resolve(this.options.files.projectRootDir, contentDir);
     }
+    const projectRootDir = this.options.files.projectRootDir;
+    if (contentDir !== projectRootDir && !isInside(projectRootDir, contentDir)) {
+      throw new Error(
+        `Security Error: Content directory "${contentDir}" resolves outside the project root "${projectRootDir}". ` +
+          `This may indicate a path traversal attempt.`,
+      );
+    }
     this.options.files.contentDir = contentDir;
     return this;
   }
@@ -187,6 +194,18 @@ export async function initClaspInstance(options: InitOptions): Promise<Clasp> {
   const filePushOrder = config.filePushOrder || []; // Default to empty array if not specified.
   // Content directory can be specified by `srcDir` or `rootDir` in .clasp.json, defaulting to project root.
   const contentDir = path.resolve(projectRoot.rootDir, config.srcDir || config.rootDir || '.');
+
+  // SECURITY: Validate that the resolved contentDir does not escape the project root.
+  // An attacker-controlled .clasp.json could set srcDir to a path like "../../.." which
+  // would resolve contentDir to "/" and bypass the isInside() jail check in fetchRemote().
+  if (contentDir !== projectRoot.rootDir && !isInside(projectRoot.rootDir, contentDir)) {
+    throw new Error(
+      `Security Error: srcDir "${config.srcDir ?? config.rootDir}" resolves outside the project root.\n` +
+        `  Resolved path: ${contentDir}\n` +
+        `  Project root:  ${projectRoot.rootDir}\n` +
+        `This may indicate a malicious .clasp.json file attempting path traversal.`,
+    );
+  }
 
   return new Clasp({
     credentials: options.credentials,

--- a/src/core/files.ts
+++ b/src/core/files.ts
@@ -55,7 +55,7 @@ function parentDirs(file: string) {
   }
   return parentDirs;
 }
-function isInside(parentPath: string, childPath: string): boolean {
+export function isInside(parentPath: string, childPath: string): boolean {
   const relative = path.relative(parentPath, childPath);
 
   return relative !== '' && !relative.startsWith('..') && !path.isAbsolute(relative);


### PR DESCRIPTION
Previously, `srcDir` was resolved using `path.resolve()` without enforcing that the resulting path stays within the project root directory. This allowed paths containing `../` to escape the project directory.

As a result, when running `clasp pull`, files fetched from the Apps Script project could be written outside the project directory.

### Impact

In scenarios where a user clones or interacts with an untrusted repository containing a crafted `.clasp.json`, this could lead to arbitrary file writes outside the project directory.

Depending on the target path and environment, this may impact user files or configuration.

### Root Cause

`path.resolve(projectRoot, srcDir)` was used without validating that the resolved path remains inside the project root. Existing safeguards only validated file paths relative to `contentDir`, not the `contentDir` itself. 

### Fix

* Reused the existing `isInside` utility from `src/core/files.ts`
* Added a validation check in `initClaspInstance` to ensure the resolved `contentDir` remains within the project root
* Throws an error if traversal outside the project root is detected

### Example (before fix)

```json
{
  "srcDir": "../../.ssh"
}
```

Running `clasp pull` would resolve this outside the project directory and write files there.

### Result

This change ensures that all file operations performed by `clasp pull` remain constrained within the project directory, preventing path traversal via `srcDir`.

### Reported by

Lakshmikanthan K (letchupkt)

---