### PR TITLE
fix(mcp): validate projectDir against permitted base paths (CWE-22 path traversal)

### DIFF
--- a/src/mcp/server.ts
+++ b/src/mcp/server.ts
@@ -16,6 +16,7 @@
 // that exposes clasp functionalities (like push, pull, create, clone, list)
 // as remotely callable tools for programmatic interaction.
 
+import os from 'os';
 import path from 'path';
 import {McpServer} from '@modelcontextprotocol/sdk/server/mcp.js';
 import {TextContent} from '@modelcontextprotocol/sdk/types.js';
@@ -25,6 +26,30 @@ import {AuthInfo} from '../auth/auth.js';
 import {getDefaultProjectName} from '../commands/create-script.js';
 import {getVersion} from '../commands/program.js';
 import {initClaspInstance} from '../core/clasp.js';
+
+/**
+ * Validates that a projectDir path is confined to a permitted base directory
+ * (the user's home directory or the current working directory).  This prevents
+ * path-traversal attacks where an attacker-controlled MCP tool call supplies an
+ * arbitrary path such as "/etc/" or "/var/www/html/" as projectDir.
+ *
+ * @param projectDir - The raw projectDir value received from the MCP tool call.
+ * @returns An error message string if the path is not permitted, or null if it is safe.
+ */
+function validateProjectDir(projectDir: string): string | null {
+  const resolved = path.resolve(projectDir);
+  const allowedBases = [os.homedir(), process.cwd()];
+  const isAllowed = allowedBases.some(
+    base => resolved === base || resolved.startsWith(base + path.sep),
+  );
+  if (!isAllowed) {
+    return (
+      `Security Error: projectDir must be within the user home directory or ` +
+      `current working directory. Resolved path "${resolved}" is not permitted.`
+    );
+  }
+  return null;
+}
 
 /**
  * Builds and configures an MCP (Model Context Protocol) server with tools
@@ -78,6 +103,16 @@ export function buildMcpServer(auth: AuthInfo) {
               text: 'Project directory is required.',
             },
           ],
+        };
+      }
+
+      // Reject paths outside permitted base directories to prevent path-traversal
+      // attacks where an attacker-controlled MCP call writes/reads arbitrary files.
+      const dirError = validateProjectDir(projectDir);
+      if (dirError) {
+        return {
+          isError: true,
+          content: [{type: 'text', text: dirError}],
         };
       }
 
@@ -156,6 +191,16 @@ export function buildMcpServer(auth: AuthInfo) {
               text: 'Project directory is required.',
             },
           ],
+        };
+      }
+
+      // Reject paths outside permitted base directories to prevent path-traversal
+      // attacks where an attacker-controlled MCP call writes/reads arbitrary files.
+      const dirError = validateProjectDir(projectDir);
+      if (dirError) {
+        return {
+          isError: true,
+          content: [{type: 'text', text: dirError}],
         };
       }
 
@@ -239,6 +284,16 @@ export function buildMcpServer(auth: AuthInfo) {
               text: 'Project directory is required.',
             },
           ],
+        };
+      }
+
+      // Reject paths outside permitted base directories to prevent path-traversal
+      // attacks where an attacker-controlled MCP call writes/reads arbitrary files.
+      const dirError = validateProjectDir(projectDir);
+      if (dirError) {
+        return {
+          isError: true,
+          content: [{type: 'text', text: dirError}],
         };
       }
 
@@ -333,6 +388,16 @@ export function buildMcpServer(auth: AuthInfo) {
               text: 'Project directory is required.',
             },
           ],
+        };
+      }
+
+      // Reject paths outside permitted base directories to prevent path-traversal
+      // attacks where an attacker-controlled MCP call writes/reads arbitrary files.
+      const dirError = validateProjectDir(projectDir);
+      if (dirError) {
+        return {
+          isError: true,
+          content: [{type: 'text', text: dirError}],
         };
       }
 


### PR DESCRIPTION
## Summary

The MCP server tools (`push_files`, `pull_files`, `create_project`, `clone_project`) accepted an attacker-controlled `projectDir` parameter with no path validation before performing filesystem operations. An attacker who can send MCP tool calls to a running `clasp mcp` process could:

1. **Arbitrary file write** — supply a malicious GAS script ID via `clone_project` with `projectDir` set to `/home/victim/` or `/var/www/html/`; the remote file content is written there.
2. **Source code exfiltration** — plant a `.clasp.json` (via `clone_project`) pointing to an attacker-owned GAS project, then call `push_files`; all `.js`/`.ts`/`.gs`/`.html` files under that directory are uploaded to the attacker's project.

The `isInside()` guard in `src/core/files.ts` was completely ineffective because its jail was rooted at the attacker-supplied `projectDir` itself — every resolved file path trivially satisfied the check.

**CWE-22** — Improper Limitation of a Pathname to a Restricted Directory
**CVSS 3.1:** `AV:L/AC:L/PR:N/UI:R/S:U/C:H/I:H/A:N` → 7.3 High
(rises to 8.1 / UI:N in prompt-injection / agentic pipeline scenarios)

## Changes

- Added `validateProjectDir()` helper in `src/mcp/server.ts` that resolves the incoming path with `path.resolve()` and rejects it unless it falls within `os.homedir()` or `process.cwd()`.
- The check is applied at the start of all four affected tool handlers **before** any `mkdir()` or further filesystem I/O.

## Test plan

- [ ] `clone_project` with `projectDir: "/etc/"` → `isError: true`, no filesystem writes.
- [ ] `push_files` with `projectDir: "/tmp/outside/"` → same rejection.
- [ ] `clone_project` with a path under `~/projects/` → proceeds normally.
- [ ] `create_project` and `pull_files` with valid paths → no regression.

Reported via Google OSS VRP.