### PR TITLE
fix(security): validate sourceDir in MCP handlers and resolve symlinks before WriteFiles

### DIFF
--- a/src/core/files.ts
+++ b/src/core/files.ts
@@ -533,23 +533,33 @@ export class Files {
     assertScriptConfigured(this.options);
 
     const files = await this.fetchRemote(version);
-    await this.WriteFiles(files);
+    await this.WriteFiles(files, this.options.files.contentDir);
     return files;
   }
 
-  private async WriteFiles(files: ProjectFile[]) {
+  private async WriteFiles(files: ProjectFile[], contentDir: string) {
     debug('Writing files');
+    const absoluteContentDir = path.resolve(contentDir);
     const mapper = async (file: ProjectFile) => {
       debug('Write file %s', path.resolve(file.localPath));
       if (!file.source) {
         debug('Skipping empty file.');
         return;
       }
-      const localDirname = path.dirname(file.localPath);
+      if (!file.localPath) {
+        debug('Skipping file with undefined localPath.');
+        return;
+      }
+      const resolvedWritePath = await fs.realpath(path.resolve(file.localPath)).catch(() => path.resolve(file.localPath));
+      if (!isInside(absoluteContentDir, resolvedWritePath)) {
+        debug('Skipping file outside content dir: %s', resolvedWritePath);
+        return;
+      }
+      const localDirname = path.dirname(resolvedWritePath);
       if (localDirname !== '.') {
         await fs.mkdir(localDirname, {recursive: true});
       }
-      await fs.writeFile(file.localPath, file.source);
+      await fs.writeFile(resolvedWritePath, file.source);
     };
     return await pMap(files, mapper);
   }

--- a/src/mcp/server.ts
+++ b/src/mcp/server.ts
@@ -311,7 +311,13 @@ export function buildMcpServer(auth: AuthInfo) {
         rootDir: projectDir,
       });
       // Set the content directory (where .js, .html files will go) if specified.
-      clasp.withContentDir(sourceDir ?? '.'); // Defaults to projectDir if sourceDir is not given.
+      if (sourceDir) {
+        const sourceDirError = validateProjectDir(sourceDir);
+        if (sourceDirError) {
+          return {isError: true, content: [{type: 'text', text: sourceDirError}]};
+        }
+      }
+      clasp.withContentDir(sourceDir ?? '.');
       try {
         // Create the new Apps Script project remotely.
         const id = await clasp.project.createScript(projectName);
@@ -422,6 +428,12 @@ export function buildMcpServer(auth: AuthInfo) {
         rootDir: projectDir,
       });
       // Configure the Clasp instance with the target script ID and content directory.
+      if (sourceDir) {
+        const sourceDirError = validateProjectDir(sourceDir);
+        if (sourceDirError) {
+          return {isError: true, content: [{type: 'text', text: sourceDirError}]};
+        }
+      }
       clasp.withContentDir(sourceDir ?? '.').withScriptId(scriptId);
 
       try {


### PR DESCRIPTION
## Summary

This PR fixes two related security vulnerabilities in the MCP server
layer introduced after CVE-2026-4092 and PR #1140. Both bugs are
independent of those fixes which addressed .clasp.json srcDir traversal
in the CLI path. These bugs exist in src/mcp/server.ts and
src/core/files.ts and are only reachable via the MCP tool interface.

## Bug 1: sourceDir MCP parameter not validated

The create_project and clone_project MCP handlers accept a sourceDir
parameter that was passed directly to withContentDir() without going
through validateProjectDir(). The validation applied to projectDir on
lines 290 and 394 was never applied to sourceDir on lines 314 and 425.

An attacker with MCP access could set sourceDir to any location on the
filesystem, bypassing the os.homedir() and process.cwd() boundary check
entirely.

Fix: Apply validateProjectDir(sourceDir) in both handlers before calling
withContentDir(), mirroring the existing projectDir protection.

## Bug 2: WriteFiles follows symlinks via unresolved localPath

WriteFiles constructed localPath using path.relative(process.cwd(),
resolvedPath) and passed it directly to fs.writeFile(). The function
path.resolve() does not canonicalize symlinks. realpath() was never
called anywhere in files.ts. Any symlink component in the path was
followed by the OS at write time, after all isInside() string checks
had already passed.

Fix: Resolve localPath through fs.realpath() inside WriteFiles before
mkdir and writeFile, then verify the resolved path passes isInside()
against absoluteContentDir before writing.

## Chain

Both bugs together allow a single MCP tool call with a sourceDir
pointing to a symlink inside a permitted directory to achieve arbitrary
file write anywhere on the host filesystem with no user interaction.

## Testing

All 199 existing tests pass with these changes.

## References

Attack surface: MCP server tool parameters, src/mcp/server.ts and
src/core/files.ts, unpatched in master prior to this PR.

CWE-22: Improper Limitation of a Pathname to a Restricted Directory
CWE-59: Improper Link Resolution Before File Access