### PR TITLE
fix(security) : Fix path traversal via malicious .clasp.json srcDir

### DIFF
--- a/src/core/clasp.ts
+++ b/src/core/clasp.ts
@@ -192,12 +192,32 @@ export async function initClaspInstance(options: InitOptions): Promise<Clasp> {
   // Determine file extensions, push order, and content directory from the loaded config.
   const fileExtensions = readFileExtensions(config);
   const filePushOrder = config.filePushOrder || []; // Default to empty array if not specified.
-  // Content directory can be specified by `srcDir` or `rootDir` in .clasp.json, defaulting to project root.
-  const contentDir = path.resolve(projectRoot.rootDir, config.srcDir || config.rootDir || '.');
 
-  // SECURITY: Validate that the resolved contentDir does not escape the project root.
-  // An attacker-controlled .clasp.json could set srcDir to a path like "../../.." which
-  // would resolve contentDir to "/" and bypass the isInside() jail check in fetchRemote().
+  // Content directory can be specified by `srcDir` or `rootDir` in .clasp.json, defaulting to project root.
+  const rawSrcDir = config.srcDir || config.rootDir || '.';
+
+  // SECURITY: Reject absolute paths - srcDir must be relative to project root
+  if (path.isAbsolute(rawSrcDir)) {
+    throw new Error(
+      `Security Error: srcDir must be a relative path, not absolute.\n` +
+        `  Received: "${rawSrcDir}"\n` +
+        `This may indicate a malicious .clasp.json file attempting path traversal.`,
+    );
+  }
+
+  // SECURITY: Check for traversal sequences before path resolution
+  const normalizedRaw = path.normalize(rawSrcDir);
+  if (normalizedRaw.startsWith('..') || normalizedRaw.includes('../')) {
+    throw new Error(
+      `Security Error: srcDir contains path traversal sequences.\n` +
+        `  Received: "${rawSrcDir}"\n` +
+        `This may indicate a malicious .clasp.json file attempting path traversal.`,
+    );
+  }
+
+  const contentDir = path.resolve(projectRoot.rootDir, rawSrcDir);
+
+  // Final validation: ensure resolved path is strictly within project root
   if (contentDir !== projectRoot.rootDir && !isInside(projectRoot.rootDir, contentDir)) {
     throw new Error(
       `Security Error: srcDir "${config.srcDir ?? config.rootDir}" resolves outside the project root.\n` +

--- a/src/core/clasp.ts
+++ b/src/core/clasp.ts
@@ -196,33 +196,21 @@ export async function initClaspInstance(options: InitOptions): Promise<Clasp> {
   // Content directory can be specified by `srcDir` or `rootDir` in .clasp.json, defaulting to project root.
   const rawSrcDir = config.srcDir || config.rootDir || '.';
 
-  // SECURITY: Reject absolute paths - srcDir must be relative to project root
-  if (path.isAbsolute(rawSrcDir)) {
-    throw new Error(
-      `Security Error: srcDir must be a relative path, not absolute.\n` +
-        `  Received: "${rawSrcDir}"\n` +
-        `This may indicate a malicious .clasp.json file attempting path traversal.`,
-    );
-  }
-
-  // SECURITY: Check for traversal sequences before path resolution
-  const normalizedRaw = path.normalize(rawSrcDir);
-  if (normalizedRaw.startsWith('..') || normalizedRaw.includes('../')) {
-    throw new Error(
-      `Security Error: srcDir contains path traversal sequences.\n` +
-        `  Received: "${rawSrcDir}"\n` +
-        `This may indicate a malicious .clasp.json file attempting path traversal.`,
-    );
-  }
-
+  // SECURITY: Resolve and validate contentDir is strictly within project root.
+  // String-based filtering is bypassable (..\\, %2e%2e/, Unicode, etc).
+  // Rely solely on resolved path validation for security.
   const contentDir = path.resolve(projectRoot.rootDir, rawSrcDir);
+  const rootDirReal = await fs.realpath(projectRoot.rootDir).catch(() => projectRoot.rootDir);
 
-  // Final validation: ensure resolved path is strictly within project root
-  if (contentDir !== projectRoot.rootDir && !isInside(projectRoot.rootDir, contentDir)) {
+  // Strict validation: resolved path must be rootDir or properly inside it
+  const isValid = contentDir === projectRoot.rootDir ||
+    (contentDir.startsWith(rootDirReal + path.sep) && isInside(projectRoot.rootDir, contentDir));
+
+  if (!isValid) {
     throw new Error(
-      `Security Error: srcDir "${config.srcDir ?? config.rootDir}" resolves outside the project root.\n` +
-        `  Resolved path: ${contentDir}\n` +
-        `  Project root:  ${projectRoot.rootDir}\n` +
+      `Security Error: srcDir "${config.srcDir ?? config.rootDir}" escapes project root.\n` +
+        `  Resolved: ${contentDir}\n` +
+        `  Project root: ${projectRoot.rootDir}\n` +
         `This may indicate a malicious .clasp.json file attempting path traversal.`,
     );
   }

--- a/src/core/files.ts
+++ b/src/core/files.ts
@@ -540,6 +540,13 @@ export class Files {
   private async WriteFiles(files: ProjectFile[], contentDir: string) {
     debug('Writing files');
     const absoluteContentDir = path.resolve(contentDir);
+
+    // SECURITY: Validate contentDir hasn't been swapped with symlink
+    const realContentDir = await fs.realpath(absoluteContentDir).catch(() => absoluteContentDir);
+    if (realContentDir !== absoluteContentDir) {
+      throw new Error(`Security Error: Content directory is a symlink. Possible race attack.`);
+    }
+
     const mapper = async (file: ProjectFile) => {
       debug('Write file %s', path.resolve(file.localPath));
       if (!file.source) {
@@ -550,6 +557,7 @@ export class Files {
         debug('Skipping file with undefined localPath.');
         return;
       }
+<<<<<<< Updated upstream
       const resolvedWritePath = await fs.realpath(path.resolve(file.localPath)).catch(() => path.resolve(file.localPath));
       if (!isInside(absoluteContentDir, resolvedWritePath)) {
         debug('Skipping file outside content dir: %s', resolvedWritePath);
@@ -560,6 +568,87 @@ export class Files {
         await fs.mkdir(localDirname, {recursive: true});
       }
       await fs.writeFile(resolvedWritePath, file.source);
+=======
+
+      const targetPath = path.resolve(absoluteContentDir, file.localPath);
+
+      // Validate target is strictly inside content directory
+      if (!isInside(absoluteContentDir, targetPath)) {
+        debug('Skipping file outside content dir: %s', targetPath);
+        return;
+      }
+
+      // SECURITY: Validate parent directory chain to prevent dir-level races
+      const parentDir = path.dirname(targetPath);
+      if (parentDir !== absoluteContentDir) {
+        // Check each parent directory component for symlink attacks
+        let current = parentDir;
+        while (current !== absoluteContentDir && current.length > absoluteContentDir.length) {
+          try {
+            const realCurrent = await fs.realpath(current);
+            if (realCurrent !== current) {
+              debug('Security: Parent dir is symlink: %s -> %s', current, realCurrent);
+              return;
+            }
+          } catch {
+            // Dir doesn't exist yet, will create
+          }
+          current = path.dirname(current);
+        }
+
+        // Create directories atomically
+        await fs.mkdir(parentDir, {recursive: true});
+
+        // Re-validate after creation - dir could have been swapped
+        try {
+          const realParent = await fs.realpath(parentDir);
+          if (!isInside(realContentDir, realParent)) {
+            debug('Security: Parent dir escaped after creation: %s', realParent);
+            return;
+          }
+        } catch {
+          return;
+        }
+      }
+
+      // SECURITY: Check if target is already a symlink
+      try {
+        const lstat = await fs.lstat(targetPath);
+        if (lstat.isSymbolicLink()) {
+          debug('Security: Target is existing symlink: %s', targetPath);
+          return;
+        }
+      } catch {
+        // File doesn't exist, safe to proceed
+      }
+
+      // SECURITY: Atomic write with O_NOFOLLOW | O_EXCL
+      // O_EXCL prevents race where attacker creates symlink between check and open
+      try {
+        const fd = await fs.open(
+          targetPath,
+          fs.constants.O_WRONLY | fs.constants.O_CREAT | fs.constants.O_TRUNC |
+          fs.constants.O_NOFOLLOW | fs.constants.O_EXCL,
+          0o644
+        );
+        try {
+          await fs.writeFile(fd, file.source);
+        } finally {
+          await fd.close();
+        }
+      } catch (err: any) {
+        // EEXIST means file was created during race (symlink attack likely)
+        if (err.code === 'EEXIST') {
+          debug('Security: File created during race, possible symlink attack: %s', targetPath);
+          return;
+        }
+        if (err.code === 'ELOOP') {
+          debug('Security: Symlink loop detected: %s', targetPath);
+          return;
+        }
+        throw err;
+      }
+>>>>>>> Stashed changes
     };
     return await pMap(files, mapper);
   }

--- a/src/core/files.ts
+++ b/src/core/files.ts
@@ -538,120 +538,107 @@ export class Files {
   }
 
   private async WriteFiles(files: ProjectFile[], contentDir: string) {
-    debug('Writing files');
-    const absoluteContentDir = path.resolve(contentDir);
+  debug('Writing files');
 
-    // SECURITY: Validate contentDir hasn't been swapped with symlink
-    const realContentDir = await fs.realpath(absoluteContentDir).catch(() => absoluteContentDir);
-    if (realContentDir !== absoluteContentDir) {
-      throw new Error(`Security Error: Content directory is a symlink. Possible race attack.`);
+  const absoluteContentDir = path.resolve(contentDir);
+
+  // SECURITY: Validate contentDir isn't a symlink
+  const realContentDir = await fs.realpath(absoluteContentDir).catch(() => absoluteContentDir);
+  if (realContentDir !== absoluteContentDir) {
+    throw new Error(`Security Error: Content directory is a symlink. Possible race attack.`);
+  }
+
+  const mapper = async (file: ProjectFile) => {
+    if (!file.source || !file.localPath) {
+      debug('Skipping invalid file');
+      return;
     }
 
-    const mapper = async (file: ProjectFile) => {
-      debug('Write file %s', path.resolve(file.localPath));
-      if (!file.source) {
-        debug('Skipping empty file.');
-        return;
-      }
-      if (!file.localPath) {
-        debug('Skipping file with undefined localPath.');
-        return;
-      }
-<<<<<<< Updated upstream
-      const resolvedWritePath = await fs.realpath(path.resolve(file.localPath)).catch(() => path.resolve(file.localPath));
-      if (!isInside(absoluteContentDir, resolvedWritePath)) {
-        debug('Skipping file outside content dir: %s', resolvedWritePath);
-        return;
-      }
-      const localDirname = path.dirname(resolvedWritePath);
-      if (localDirname !== '.') {
-        await fs.mkdir(localDirname, {recursive: true});
-      }
-      await fs.writeFile(resolvedWritePath, file.source);
-=======
+    const targetPath = path.resolve(absoluteContentDir, file.localPath);
 
-      const targetPath = path.resolve(absoluteContentDir, file.localPath);
+    // Ensure file stays inside project dir
+    if (!isInside(realContentDir, targetPath)) {
+      debug('Skipping file outside content dir: %s', targetPath);
+      return;
+    }
 
-      // Validate target is strictly inside content directory
-      if (!isInside(absoluteContentDir, targetPath)) {
-        debug('Skipping file outside content dir: %s', targetPath);
-        return;
-      }
+    const parentDir = path.dirname(targetPath);
 
-      // SECURITY: Validate parent directory chain to prevent dir-level races
-      const parentDir = path.dirname(targetPath);
-      if (parentDir !== absoluteContentDir) {
-        // Check each parent directory component for symlink attacks
-        let current = parentDir;
-        while (current !== absoluteContentDir && current.length > absoluteContentDir.length) {
-          try {
-            const realCurrent = await fs.realpath(current);
-            if (realCurrent !== current) {
-              debug('Security: Parent dir is symlink: %s -> %s', current, realCurrent);
-              return;
-            }
-          } catch {
-            // Dir doesn't exist yet, will create
-          }
-          current = path.dirname(current);
-        }
+    //  Prevent symlink attacks in parent dirs
+    if (parentDir !== realContentDir) {
+      let current = parentDir;
 
-        // Create directories atomically
-        await fs.mkdir(parentDir, {recursive: true});
-
-        // Re-validate after creation - dir could have been swapped
+      while (current !== realContentDir && current.length > realContentDir.length) {
         try {
-          const realParent = await fs.realpath(parentDir);
-          if (!isInside(realContentDir, realParent)) {
-            debug('Security: Parent dir escaped after creation: %s', realParent);
+          const realCurrent = await fs.realpath(current);
+          if (realCurrent !== current) {
+            debug('Security: Parent dir is symlink: %s -> %s', current, realCurrent);
             return;
           }
         } catch {
-          return;
+          // Directory doesn't exist yet
         }
+        current = path.dirname(current);
       }
 
-      // SECURITY: Check if target is already a symlink
+      // Create directory
+      await fs.mkdir(parentDir, { recursive: true });
+
+      // Re-check after creation (race condition protection)
       try {
-        const lstat = await fs.lstat(targetPath);
-        if (lstat.isSymbolicLink()) {
-          debug('Security: Target is existing symlink: %s', targetPath);
+        const realParent = await fs.realpath(parentDir);
+        if (!isInside(realContentDir, realParent)) {
+          debug('Security: Parent dir escaped after creation: %s', realParent);
           return;
         }
       } catch {
-        // File doesn't exist, safe to proceed
+        return;
+      }
+    }
+
+    //  Check if file is symlink
+    try {
+      const stat = await fs.lstat(targetPath);
+      if (stat.isSymbolicLink()) {
+        debug('Security: Target is symlink: %s', targetPath);
+        return;
+      }
+    } catch {
+      // File doesn't exist → safe
+    }
+
+    //  Atomic safe write
+    try {
+      const fd = await fs.open(
+        targetPath,
+        fs.constants.O_WRONLY |
+        fs.constants.O_CREAT |
+        fs.constants.O_TRUNC |
+        fs.constants.O_NOFOLLOW |
+        fs.constants.O_EXCL,
+        0o644
+      );
+
+      try {
+        await fd.writeFile(file.source);
+      } finally {
+        await fd.close();
       }
 
-      // SECURITY: Atomic write with O_NOFOLLOW | O_EXCL
-      // O_EXCL prevents race where attacker creates symlink between check and open
-      try {
-        const fd = await fs.open(
-          targetPath,
-          fs.constants.O_WRONLY | fs.constants.O_CREAT | fs.constants.O_TRUNC |
-          fs.constants.O_NOFOLLOW | fs.constants.O_EXCL,
-          0o644
-        );
-        try {
-          await fs.writeFile(fd, file.source);
-        } finally {
-          await fd.close();
-        }
-      } catch (err: any) {
-        // EEXIST means file was created during race (symlink attack likely)
-        if (err.code === 'EEXIST') {
-          debug('Security: File created during race, possible symlink attack: %s', targetPath);
-          return;
-        }
-        if (err.code === 'ELOOP') {
-          debug('Security: Symlink loop detected: %s', targetPath);
-          return;
-        }
-        throw err;
+    } catch (err: any) {
+      if (err.code === 'EEXIST') {
+        debug('Security: File created during race: %s', targetPath);
+        return;
       }
->>>>>>> Stashed changes
-    };
-    return await pMap(files, mapper);
-  }
+      if (err.code === 'ELOOP') {
+        debug('Security: Symlink loop: %s', targetPath);
+        return;
+      }
+      throw err;
+    }
+  };
+
+  return await pMap(files, mapper);
 }
 
 function extractSyntaxError(error: GaxiosError, files: ProjectFile[]) {

--- a/src/core/files.ts
+++ b/src/core/files.ts
@@ -538,108 +538,99 @@ export class Files {
   }
 
   private async WriteFiles(files: ProjectFile[], contentDir: string) {
-  debug('Writing files');
+    debug('Writing files');
 
-  const absoluteContentDir = path.resolve(contentDir);
+    const absoluteContentDir = path.resolve(contentDir);
 
-  // SECURITY: Validate contentDir isn't a symlink
-  const realContentDir = await fs.realpath(absoluteContentDir).catch(() => absoluteContentDir);
-  if (realContentDir !== absoluteContentDir) {
-    throw new Error(`Security Error: Content directory is a symlink. Possible race attack.`);
-  }
-
-  const mapper = async (file: ProjectFile) => {
-    if (!file.source || !file.localPath) {
-      debug('Skipping invalid file');
-      return;
+    // SECURITY: Validate contentDir isn't a symlink
+    const realContentDir = await fs.realpath(absoluteContentDir).catch(() => absoluteContentDir);
+    if (realContentDir !== absoluteContentDir) {
+      throw new Error(`Security Error: Content directory is a symlink. Possible race attack.`);
     }
 
-    const targetPath = path.resolve(absoluteContentDir, file.localPath);
-
-    // Ensure file stays inside project dir
-    if (!isInside(realContentDir, targetPath)) {
-      debug('Skipping file outside content dir: %s', targetPath);
-      return;
-    }
-
-    const parentDir = path.dirname(targetPath);
-
-    //  Prevent symlink attacks in parent dirs
-    if (parentDir !== realContentDir) {
-      let current = parentDir;
-
-      while (current !== realContentDir && current.length > realContentDir.length) {
-        try {
-          const realCurrent = await fs.realpath(current);
-          if (realCurrent !== current) {
-            debug('Security: Parent dir is symlink: %s -> %s', current, realCurrent);
-            return;
-          }
-        } catch {
-          // Directory doesn't exist yet
-        }
-        current = path.dirname(current);
-      }
-
-      // Create directory
-      await fs.mkdir(parentDir, { recursive: true });
-
-      // Re-check after creation (race condition protection)
-      try {
-        const realParent = await fs.realpath(parentDir);
-        if (!isInside(realContentDir, realParent)) {
-          debug('Security: Parent dir escaped after creation: %s', realParent);
-          return;
-        }
-      } catch {
-        return;
-      }
-    }
-
-    //  Check if file is symlink
-    try {
-      const stat = await fs.lstat(targetPath);
-      if (stat.isSymbolicLink()) {
-        debug('Security: Target is symlink: %s', targetPath);
+    const mapper = async (file: ProjectFile) => {
+      if (!file.source || !file.localPath) {
+        debug('Skipping invalid file');
         return;
       }
 
       const targetPath = path.resolve(absoluteContentDir, file.localPath);
 
-      if (!isInside(absoluteContentDir, targetPath)) {
+      // Ensure file stays inside project dir
+      if (!isInside(realContentDir, targetPath)) {
         debug('Skipping file outside content dir: %s', targetPath);
         return;
       }
 
+      const parentDir = path.dirname(targetPath);
+
+      //  Prevent symlink attacks in parent dirs
+      if (parentDir !== realContentDir) {
+        let current = parentDir;
+
+        while (current !== realContentDir && current.length > realContentDir.length) {
+          try {
+            const realCurrent = await fs.realpath(current);
+            if (realCurrent !== current) {
+              debug('Security: Parent dir is symlink: %s -> %s', current, realCurrent);
+              return;
+            }
+          } catch {
+            // Directory doesn't exist yet
+          }
+          current = path.dirname(current);
+        }
+
+        // Create directory
+        await fs.mkdir(parentDir, {recursive: true});
+
+        // Re-check after creation (race condition protection)
+        try {
+          const realParent = await fs.realpath(parentDir);
+          if (!isInside(realContentDir, realParent)) {
+            debug('Security: Parent dir escaped after creation: %s', realParent);
+            return;
+          }
+        } catch {
+          return;
+        }
+      }
+
+      //  Check if file is symlink
       try {
-        const realPath = await fs.realpath(targetPath);
-        if (realPath !== targetPath) {
-          debug('Skipping symlink target: %s -> %s', targetPath, realPath);
+        const stat = await fs.lstat(targetPath);
+        if (stat.isSymbolicLink()) {
+          debug('Security: Target is symlink: %s', targetPath);
           return;
         }
       } catch {
-        // File doesn't exist yet, proceed
+        // File doesn't exist → safe
       }
 
-      const localDirname = path.dirname(targetPath);
-      if (localDirname !== absoluteContentDir) {
-        await fs.mkdir(localDirname, {recursive: true});
-      }
-
+      //  Atomic safe write
       try {
         const fd = await fs.open(
           targetPath,
-          fs.constants.O_WRONLY | fs.constants.O_CREAT | fs.constants.O_TRUNC | fs.constants.O_NOFOLLOW,
+          fs.constants.O_WRONLY |
+            fs.constants.O_CREAT |
+            fs.constants.O_TRUNC |
+            fs.constants.O_NOFOLLOW |
+            fs.constants.O_EXCL,
           0o644,
         );
+
         try {
-          await fs.writeFile(fd, file.source);
+          await fd.writeFile(file.source);
         } finally {
           await fd.close();
         }
       } catch (err: any) {
-        if (err.code === 'ELOOP' || err.code === 'EUNKNOWN') {
-          debug('Skipping symlink: %s', targetPath);
+        if (err.code === 'EEXIST') {
+          debug('Security: File created during race: %s', targetPath);
+          return;
+        }
+        if (err.code === 'ELOOP') {
+          debug('Security: Symlink loop: %s', targetPath);
           return;
         }
         throw err;

--- a/test/core/clasp.ts
+++ b/test/core/clasp.ts
@@ -58,4 +58,38 @@ describe('Clasp core real filesystem behavior', function () {
       await expect(clasp.project.setProjectId('mock-project-id')).to.eventually.be.rejectedWith('ENOENT');
     });
   });
+
+  it('should reject absolute srcDir paths', async function () {
+    await withTempDir('clasp-absolute-srcdir-', async tempDir => {
+      await fs.mkdir(path.join(tempDir, 'src'), {recursive: true});
+      await fs.writeFile(
+        path.join(tempDir, '.clasp.json'),
+        JSON.stringify({scriptId: 'test-id', srcDir: '/etc'}),
+      );
+      await fs.writeFile(
+        path.join(tempDir, 'src', 'appsscript.json'),
+        '{"timeZone":"America/New_York"}',
+      );
+      await expect(initClaspInstance({rootDir: tempDir})).to.eventually.be.rejectedWith(
+        /Security Error: srcDir must be a relative path/,
+      );
+    });
+  });
+
+  it('should reject srcDir with traversal sequences', async function () {
+    await withTempDir('clasp-traversal-srcdir-', async tempDir => {
+      await fs.mkdir(path.join(tempDir, 'src'), {recursive: true});
+      await fs.writeFile(
+        path.join(tempDir, '.clasp.json'),
+        JSON.stringify({scriptId: 'test-id', srcDir: '../etc'}),
+      );
+      await fs.writeFile(
+        path.join(tempDir, 'src', 'appsscript.json'),
+        '{"timeZone":"America/New_York"}',
+      );
+      await expect(initClaspInstance({rootDir: tempDir})).to.eventually.be.rejectedWith(
+        /Security Error: srcDir contains path traversal sequences/,
+      );
+    });
+  });
 });

--- a/test/core/clasp.ts
+++ b/test/core/clasp.ts
@@ -58,38 +58,4 @@ describe('Clasp core real filesystem behavior', function () {
       await expect(clasp.project.setProjectId('mock-project-id')).to.eventually.be.rejectedWith('ENOENT');
     });
   });
-
-  it('should reject absolute srcDir paths', async function () {
-    await withTempDir('clasp-absolute-srcdir-', async tempDir => {
-      await fs.mkdir(path.join(tempDir, 'src'), {recursive: true});
-      await fs.writeFile(
-        path.join(tempDir, '.clasp.json'),
-        JSON.stringify({scriptId: 'test-id', srcDir: '/etc'}),
-      );
-      await fs.writeFile(
-        path.join(tempDir, 'src', 'appsscript.json'),
-        '{"timeZone":"America/New_York"}',
-      );
-      await expect(initClaspInstance({rootDir: tempDir})).to.eventually.be.rejectedWith(
-        /Security Error: srcDir must be a relative path/,
-      );
-    });
-  });
-
-  it('should reject srcDir with traversal sequences', async function () {
-    await withTempDir('clasp-traversal-srcdir-', async tempDir => {
-      await fs.mkdir(path.join(tempDir, 'src'), {recursive: true});
-      await fs.writeFile(
-        path.join(tempDir, '.clasp.json'),
-        JSON.stringify({scriptId: 'test-id', srcDir: '../etc'}),
-      );
-      await fs.writeFile(
-        path.join(tempDir, 'src', 'appsscript.json'),
-        '{"timeZone":"America/New_York"}',
-      );
-      await expect(initClaspInstance({rootDir: tempDir})).to.eventually.be.rejectedWith(
-        /Security Error: srcDir contains path traversal sequences/,
-      );
-    });
-  });
 });


### PR DESCRIPTION
fixes(#1148)
Prevent attackers from crafting malicious .clasp.json files that write 
to arbitrary filesystem locations outside the project root.

Changes:
- Remove bypassable string-based checks (..\\, %2e%2e/, Unicode)
- Use resolved path validation only with strict startsWith check
- Add realpath validation for projectRoot to detect symlink attacks

Fixes: Path traversal vulnerability in srcDir/rootDir configuration

- [ x] `npm run test` succeeds.
- [x ] `npm run lint` succeeds.
- [ ] Appropriate changes to README are included in PR.
