### PR TITLE
chore: upgrade googleapis to ^149.0.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -20,7 +20,7 @@
         "find-up": "^7.0.0",
         "fuzzy": "^0.1.3",
         "google-auth-library": "^9.15.1",
-        "googleapis": "^148.0.0",
+        "googleapis": "^149.0.0",
         "googleapis-common": "7.2.0",
         "inflection": "^3.0.2",
         "inquirer": "^12.6.0",
@@ -2506,9 +2506,10 @@
       }
     },
     "node_modules/googleapis": {
-      "version": "148.0.0",
-      "resolved": "https://registry.npmjs.org/googleapis/-/googleapis-148.0.0.tgz",
-      "integrity": "sha512-8PDG5VItm6E1TdZWDqtRrUJSlBcNwz0/MwCa6AL81y/RxPGXJRUwKqGZfCoVX1ZBbfr3I4NkDxBmeTyOAZSWqw==",
+      "version": "149.0.0",
+      "resolved": "https://registry.npmjs.org/googleapis/-/googleapis-149.0.0.tgz",
+      "integrity": "sha512-LTMc/njwYy7KTeaUHDcQt7KxftHyghdzm2XzbL46PRLd1AXB09utT9Po2ZJn2X0EApz0pE2T5x5A9zM8iue6zw==",
+      "license": "Apache-2.0",
       "dependencies": {
         "google-auth-library": "^9.0.0",
         "googleapis-common": "^7.0.0"

--- a/package.json
+++ b/package.json
@@ -66,7 +66,7 @@
     "find-up": "^7.0.0",
     "fuzzy": "^0.1.3",
     "google-auth-library": "^9.15.1",
-    "googleapis": "^148.0.0",
+    "googleapis": "^149.0.0",
     "googleapis-common": "7.2.0",
     "inflection": "^3.0.2",
     "inquirer": "^12.6.0",

--- a/src/core/files.ts
+++ b/src/core/files.ts
@@ -574,7 +574,11 @@ export class Files {
       }
 
       try {
-        const fd = await fs.open(targetPath, fs.constants.O_WRONLY | fs.constants.O_CREAT | fs.constants.O_TRUNC | fs.constants.O_NOFOLLOW, 0o644);
+        const fd = await fs.open(
+          targetPath,
+          fs.constants.O_WRONLY | fs.constants.O_CREAT | fs.constants.O_TRUNC | fs.constants.O_NOFOLLOW,
+          0o644,
+        );
         try {
           await fs.writeFile(fd, file.source);
         } finally {


### PR DESCRIPTION
Upgrades the `googleapis` dependency to `^149.0.0` as requested in issue #1150.
Also includes auto-formatting in `src/core/files.ts` applied by `biome` during the process.

---
*PR created automatically by Jules for task [1497012540310712194](https://jules.google.com/task/1497012540310712194) started by @sqrrrl*