### PR TITLE
fix(create-script): accept --type webapp and --type api as standalone aliases

### DIFF
--- a/src/commands/create-script.ts
+++ b/src/commands/create-script.ts
@@ -30,6 +30,12 @@ const DRIVE_FILE_MIMETYPES: Record<string, string> = {
   slides: 'application/vnd.google-apps.presentation',
 };
 
+// Types that produce a standalone script. `webapp` and `api` are accepted as
+// aliases of `standalone` because clasp's `--type` only controls how the
+// script is *created*; deploying it as a web app or API executable happens
+// separately via `clasp create-deployment`.
+const STANDALONE_SCRIPT_TYPES: ReadonlySet<string> = new Set(['standalone', 'webapp', 'api']);
+
 interface CommandOptions extends GlobalOptions {
   readonly parentId?: string;
   readonly rootDir?: string;
@@ -71,13 +77,17 @@ export const command = new Command('create-script')
     let createdParentId: string | undefined;
 
     // Handle container-bound script creation (e.g., for Sheets, Docs, Forms, Slides).
-    if (type && type !== 'standalone') {
+    if (!STANDALONE_SCRIPT_TYPES.has(type)) {
       const mimeType = DRIVE_FILE_MIMETYPES[type]; // Look up MIME type for the specified container type.
       if (!mimeType) {
-        // If the type is invalid or not supported for container-bound scripts.
-        const msg = intl.formatMessage({
-          defaultMessage: 'Invalid container file type',
-        });
+        // If the type is not one of the known standalone or container-bound types.
+        const validTypes = [...STANDALONE_SCRIPT_TYPES, ...Object.keys(DRIVE_FILE_MIMETYPES)].join(', ');
+        const msg = intl.formatMessage(
+          {
+            defaultMessage: 'Invalid script type "{type}". Valid types are: {validTypes}.',
+          },
+          {type, validTypes},
+        );
         this.error(msg);
       }
 
@@ -130,6 +140,22 @@ export const command = new Command('create-script')
           },
         );
         console.log(successMessage);
+
+        // Surface the next step for users who asked for a web app or API
+        // executable. The script itself is always created as standalone;
+        // exposing it as a web app or API happens at deployment time.
+        if (type === 'webapp' || type === 'api') {
+          const deploymentKind = type === 'webapp' ? 'web app' : 'API executable';
+          const manifestField = type === 'webapp' ? 'webApp' : 'executionApi';
+          const deploymentTip = intl.formatMessage(
+            {
+              defaultMessage:
+                'Tip: to deploy this script as a {deploymentKind}, configure "{manifestField}" in appsscript.json and run `clasp create-deployment`.',
+            },
+            {deploymentKind, manifestField},
+          );
+          console.log(deploymentTip);
+        }
       }
     }
 

--- a/test/commands/create-script.ts
+++ b/test/commands/create-script.ts
@@ -137,6 +137,46 @@ describe('Create script command', function () {
       const json = JSON.parse(out.stdout);
       expect(json.scriptId).to.equal('mock-script-id');
     });
+
+    it('should treat --type webapp as a standalone script and print a deployment tip', async function () {
+      mockCreateScript({
+        scriptId: 'mock-script-id',
+        title: getDefaultProjectName(process.cwd()),
+      });
+      mockScriptDownload({
+        scriptId: 'mock-script-id',
+      });
+      const out = await runCommand(['create', '--type', 'webapp']);
+      expect('appsscript.json').to.be.a.realFile;
+      expect('Code.js').to.be.a.realFile;
+      expect(out.stdout).to.contain('Cloned');
+      expect(out.stdout).to.contain('web app');
+      expect(out.stdout).to.contain('webApp');
+    });
+
+    it('should treat --type api as a standalone script and print a deployment tip', async function () {
+      mockCreateScript({
+        scriptId: 'mock-script-id',
+        title: getDefaultProjectName(process.cwd()),
+      });
+      mockScriptDownload({
+        scriptId: 'mock-script-id',
+      });
+      const out = await runCommand(['create', '--type', 'api']);
+      expect('appsscript.json').to.be.a.realFile;
+      expect('Code.js').to.be.a.realFile;
+      expect(out.stdout).to.contain('Cloned');
+      expect(out.stdout).to.contain('API executable');
+      expect(out.stdout).to.contain('executionApi');
+    });
+
+    it('should reject an unknown --type with a helpful message listing valid types', async function () {
+      const out = await runCommand(['create', '--type', 'spreadsheet']);
+      expect(out.stderr).to.contain('spreadsheet');
+      expect(out.stderr).to.contain('standalone');
+      expect(out.stderr).to.contain('webapp');
+      expect(out.stderr).to.contain('sheets');
+    });
   });
   describe('With existing project, authenticated', function () {
     beforeEach(function () {


### PR DESCRIPTION
Fixes #1154.

The `--type` option advertises `webapp` and `api` as valid values but the code only handled `standalone` and the container types in `DRIVE_FILE_MIMETYPES`. Anything else fell through to "Invalid container file type", so users following the documented examples hit a wall.

Treat `webapp` and `api` as aliases of `standalone` (which is what they were in clasp v2 and what they effectively are now, since deploying as a web app or API happens through `clasp create-deployment`, not at script creation). When one of those aliases is used, print a short tip pointing at `clasp create-deployment` and the relevant `appsscript.json` field. The error message for genuinely unknown types now lists every valid value.

Tests added in `test/commands/create-script.ts` cover both aliases and the invalid-type case.

Note: `npm run check` (biome + tsc) passes locally. `npm test` cannot run on Node 24 in this repo today (mocha loader hits `resolveSync` not implemented), reproducible on `master` without this diff, so the new tests will be confirmed by CI.