### PR TITLE
Fix: Print help instead of throwing error on unknown commands

### DIFF
--- a/original_program.ts
+++ b/original_program.ts
@@ -1,0 +1,17 @@
+// ... (skip down to line 179)
+  program.on('command:*', async function (this: Command, op) {
+    const msg = intl.formatMessage(
+      {
+        defaultMessage: 'Unknown command "clasp {command}"',
+      },
+      {
+        command: op[0],
+      },
+    );
+    this.error(msg as string);
+  });
+
+  program.error;
+
+  return program;
+}

--- a/src/commands/program.ts
+++ b/src/commands/program.ts
@@ -193,7 +193,5 @@ export function makeProgram(exitOverride?: (err: CommanderError) => void) {
     program.help();
   });
 
-  program.showHelpAfterError();
-
   return program;
 }

--- a/src/commands/program.ts
+++ b/src/commands/program.ts
@@ -179,7 +179,7 @@ export function makeProgram(exitOverride?: (err: CommanderError) => void) {
     cmd.copyInheritedSettings(program);
   }
 
-  program.on('command:*', async function (this: Command, op) {
+  program.on('command:*', function (this: Command, op) {
     const msg = intl.formatMessage(
       {
         defaultMessage: 'Unknown command "clasp {command}"',
@@ -188,10 +188,12 @@ export function makeProgram(exitOverride?: (err: CommanderError) => void) {
         command: op[0],
       },
     );
-    this.error(msg as string);
+    console.error(msg as string);
+    process.exitCode = 1;
+    program.help();
   });
 
-  program.error;
+  program.showHelpAfterError();
 
   return program;
 }

--- a/src/core/clasp.ts
+++ b/src/core/clasp.ts
@@ -203,7 +203,8 @@ export async function initClaspInstance(options: InitOptions): Promise<Clasp> {
   const rootDirReal = await fs.realpath(projectRoot.rootDir).catch(() => projectRoot.rootDir);
 
   // Strict validation: resolved path must be rootDir or properly inside it
-  const isValid = contentDir === projectRoot.rootDir ||
+  const isValid =
+    contentDir === projectRoot.rootDir ||
     (contentDir.startsWith(rootDirReal + path.sep) && isInside(projectRoot.rootDir, contentDir));
 
   if (!isValid) {

--- a/test.js
+++ b/test.js
@@ -1,8 +1,0 @@
-import {makeProgram} from './build/src/commands/program.js';
-
-const program = makeProgram((err) => {
-  console.log("ERR CODE:", err.code);
-  throw err;
-});
-
-program.parseAsync(['node', 'clasp', 'abc']).catch(e => console.log("CAUGHT CODE:", e.code));

--- a/test.js
+++ b/test.js
@@ -1,0 +1,8 @@
+import {makeProgram} from './build/src/commands/program.js';
+
+const program = makeProgram((err) => {
+  console.log("ERR CODE:", err.code);
+  throw err;
+});
+
+program.parseAsync(['node', 'clasp', 'abc']).catch(e => console.log("CAUGHT CODE:", e.code));

--- a/test/commands/program.ts
+++ b/test/commands/program.ts
@@ -74,9 +74,7 @@ describe('Unknown commands', () => {
     const result = await runCommand(['nonexistentcommand'], false);
 
     expect(result.stderr).to.contain('Unknown command "clasp nonexistentcommand"');
-    // `commander.help` throws when exitOverride is enabled (as runCommand does),
-    // and outputs the help to stdout usually, but let's just check the message and exit code.
-    expect(result.message).to.contain('(outputHelp)');
+    expect(result.stdout).to.contain('Usage: clasp <command> [options]');
 
     // Also the global process.exitCode should be set to 1 by our patch
     expect(process.exitCode).to.equal(1);

--- a/test/commands/program.ts
+++ b/test/commands/program.ts
@@ -19,6 +19,7 @@ import {expect} from 'chai';
 import {describe, it} from 'mocha';
 
 import {makeProgram} from '../../src/commands/program.js';
+import {runCommand} from './utils.js';
 
 describe('Consistency between imported and registered commands', () => {
   const expectedCommands = [
@@ -65,5 +66,20 @@ describe('Consistency between imported and registered commands', () => {
   it('should have the same number of registered commands as imports', () => {
     const program = makeProgram();
     expect(program.commands).to.length(expectedCommands.length);
+  });
+});
+
+describe('Unknown commands', () => {
+  it('should print help when an unknown command is provided', async () => {
+    const result = await runCommand(['nonexistentcommand'], false);
+
+    expect(result.stderr).to.contain('Unknown command "clasp nonexistentcommand"');
+    // `commander.help` throws when exitOverride is enabled (as runCommand does),
+    // and outputs the help to stdout usually, but let's just check the message and exit code.
+    expect(result.message).to.contain('(outputHelp)');
+
+    // Also the global process.exitCode should be set to 1 by our patch
+    expect(process.exitCode).to.equal(1);
+    process.exitCode = 0; // reset for subsequent tests
   });
 });


### PR DESCRIPTION
Resolves https://github.com/google/clasp/issues/1156 by ensuring `clasp <unknown_cmd>` properly prints the command help and exits with status `1`, instead of printing a raw unhandled stack trace. Added a unit test.

---
*PR created automatically by Jules for task [17979674611158503235](https://jules.google.com/task/17979674611158503235) started by @sqrrrl*