### PR TITLE
docs: update Cloud Logging references

### DIFF
--- a/README.md
+++ b/README.md
@@ -661,7 +661,7 @@ Ensures your script is configured with a GCP project ID, which is required to vi
 
 ### Logs
 
-Prints out most recent the _StackDriver logs_. These are logs from `console.log`, not `Logger.log`.
+Prints out most recent the _Cloud Logging logs_. These are logs from `console.log`, not `Logger.log`.
 
 #### Options
 

--- a/src/auth/auth.ts
+++ b/src/auth/auth.ts
@@ -289,7 +289,7 @@ export async function createApplicationDefaultCredentials() {
       'https://www.googleapis.com/auth/drive.metadata.readonly', // Drive metadata
       'https://www.googleapis.com/auth/drive.file', // Create Drive files
       'https://www.googleapis.com/auth/service.management', // Cloud Project Service Management API
-      'https://www.googleapis.com/auth/logging.read', // StackDriver logs
+      'https://www.googleapis.com/auth/logging.read', // Cloud Logging logs
       'https://www.googleapis.com/auth/userinfo.email', // User email address
       'https://www.googleapis.com/auth/userinfo.profile',
       'https://www.googleapis.com/auth/cloud-platform',

--- a/src/commands/login.ts
+++ b/src/commands/login.ts
@@ -33,7 +33,7 @@ const DEFAULT_SCOPES = [
   'https://www.googleapis.com/auth/drive.metadata.readonly', // Drive metadata
   'https://www.googleapis.com/auth/drive.file', // Create Drive files
   'https://www.googleapis.com/auth/service.management', // Cloud Project Service Management API
-  'https://www.googleapis.com/auth/logging.read', // StackDriver logs
+  'https://www.googleapis.com/auth/logging.read', // Cloud Logging logs
   'https://www.googleapis.com/auth/userinfo.email', // User email address
   'https://www.googleapis.com/auth/userinfo.profile',
   'https://www.googleapis.com/auth/cloud-platform',


### PR DESCRIPTION
- [x] `npm run test` succeeds.
- [x] `npm run lint` succeeds.
- [x] Appropriate changes to README are included in PR.

This updates the remaining StackDriver log references to Cloud Logging in the logs documentation and OAuth scope comments.

Validation:
- `npm run lint`
- `npx -p node@20 npm run test`