### PR TITLE
feat: add add-library command

### DIFF
--- a/src/commands/add-library.ts
+++ b/src/commands/add-library.ts
@@ -1,0 +1,59 @@
+// Copyright 2025 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// This file defines the 'add-library' command for the clasp CLI.
+
+import {Command} from 'commander';
+import {Clasp} from '../core/clasp.js';
+import {intl} from '../intl.js';
+import {GlobalOptions} from './utils.js';
+
+interface CommandOptions extends GlobalOptions {
+  readonly libraryVersion?: string;
+  readonly symbol?: string;
+  readonly dev?: boolean;
+}
+
+export const command = new Command('add-library')
+  .description('Add a library to the project manifest.')
+  .argument('<scriptId>', 'The script ID of the library to add')
+  .option('-l, --libraryVersion <version>', 'The version of the library to use', '1')
+  .option('-s, --symbol <symbol>', 'The identifier used to call the library from your script')
+  .option('--dev', 'Use the development mode (HEAD) version of the library')
+  .action(async function (this: Command, libraryId: string) {
+    const options: CommandOptions = this.optsWithGlobals();
+    const clasp: Clasp = options.clasp;
+
+    const version = options.libraryVersion ?? '1';
+    const userSymbol = options.symbol ?? libraryId.substring(0, 8);
+
+    await clasp.project.addLibrary(libraryId, version, userSymbol, Boolean(options.dev));
+
+    if (options.json) {
+      console.log(JSON.stringify({success: true, libraryId, version, userSymbol}, null, 2));
+      return;
+    }
+
+    const successMessage = intl.formatMessage(
+      {
+        defaultMessage: 'Added library {userSymbol} ({libraryId}) version {version}.',
+      },
+      {
+        userSymbol,
+        libraryId,
+        version,
+      },
+    );
+    console.log(successMessage);
+  });

--- a/src/commands/program.ts
+++ b/src/commands/program.ts
@@ -19,6 +19,7 @@
 import {Command, CommanderError, Option} from 'commander';
 import {PROJECT_NAME} from '../constants.js';
 
+import {command as addLibraryCommand} from './add-library.js';
 import {command as cloneCommand} from './clone-script.js';
 import {command as createDeploymentCommand} from './create-deployment.js';
 import {command as createCommand} from './create-script.js';
@@ -148,6 +149,7 @@ export function makeProgram(exitOverride?: (err: CommanderError) => void) {
     openAuthCommand,
     cloneCommand,
     createCommand,
+    addLibraryCommand,
     pushCommand,
     pullCommand,
     createDeploymentCommand,

--- a/src/core/project.ts
+++ b/src/core/project.ts
@@ -25,7 +25,7 @@ import {fetchWithPages} from './utils.js';
 import {ClaspOptions, assertAuthenticated, assertScriptConfigured, handleApiError} from './utils.js';
 
 import path from 'path';
-import {Manifest} from './manifest.js';
+import {Library, Manifest} from './manifest.js';
 
 const debug = Debug('clasp:core');
 
@@ -494,5 +494,35 @@ export class Project {
     const content = await fs.readFile(manifestPath);
     const manifest: Manifest = JSON.parse(content.toString());
     return manifest;
+  }
+
+  /**
+   * Adds a library dependency to the `appsscript.json` manifest, or updates it
+   * if a library with the same `libraryId` is already present.
+   * @param {string} libraryId - The script ID of the library to add.
+   * @param {string} version - The version number or label of the library.
+   * @param {string} userSymbol - The variable name used to access the library in script.
+   * @param {boolean} [developmentMode=false] - Whether to use the library's development mode (HEAD).
+   * @returns {Promise<void>}
+   * @throws {Error} If the script is not configured or the manifest file cannot be read/parsed.
+   */
+  async addLibrary(libraryId: string, version: string, userSymbol: string, developmentMode = false): Promise<void> {
+    debug('Adding library %s@%s as %s', libraryId, version, userSymbol);
+    assertScriptConfigured(this.options);
+
+    const manifest = await this.readManifest();
+    const library: Library = {libraryId, version, userSymbol, developmentMode};
+
+    const libraries = manifest.dependencies?.libraries ?? [];
+    const index = libraries.findIndex(existing => existing.libraryId === libraryId);
+    if (index === -1) {
+      libraries.push(library);
+    } else {
+      libraries[index] = library;
+    }
+    manifest.dependencies = {...manifest.dependencies, libraries};
+
+    const manifestPath = path.join(this.options.files.contentDir, 'appsscript.json');
+    await fs.writeFile(manifestPath, JSON.stringify(manifest, null, 2));
   }
 }

--- a/test/commands/add-library.ts
+++ b/test/commands/add-library.ts
@@ -1,0 +1,98 @@
+// Copyright 2025 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// This file contains tests for the 'add-library' command.
+
+import fs from 'fs';
+import os from 'os';
+import path from 'path';
+import {fileURLToPath} from 'url';
+import {expect} from 'chai';
+import {afterEach, beforeEach, describe, it} from 'mocha';
+import mockfs from 'mock-fs';
+import {useChaiExtensions} from '../helpers.js';
+import {mockOAuthRefreshRequest, resetMocks, setupMocks} from '../mocks.js';
+import {runCommand} from './utils.js';
+
+useChaiExtensions();
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+
+describe('Add library command', function () {
+  beforeEach(function () {
+    setupMocks();
+    mockOAuthRefreshRequest();
+  });
+
+  afterEach(function () {
+    resetMocks();
+  });
+
+  describe('With project, authenticated', function () {
+    beforeEach(function () {
+      mockfs({
+        'appsscript.json': mockfs.load(path.resolve(__dirname, '../fixtures/appsscript-no-services.json')),
+        '.clasp.json': mockfs.load(path.resolve(__dirname, '../fixtures/dot-clasp-no-settings.json')),
+        [path.resolve(os.homedir(), '.clasprc.json')]: mockfs.load(
+          path.resolve(__dirname, '../fixtures/dot-clasprc-authenticated.json'),
+        ),
+      });
+    });
+
+    it('should add a library to the manifest', async function () {
+      const out = await runCommand(['add-library', 'mock-library-id', '--libraryVersion', '3', '--symbol', 'MyLib']);
+      expect(out.stdout).to.contain('Added library MyLib');
+
+      const manifest = JSON.parse(fs.readFileSync('appsscript.json', 'utf8'));
+      expect(manifest).to.containSubset({
+        dependencies: {
+          libraries: [
+            {
+              userSymbol: 'MyLib',
+              libraryId: 'mock-library-id',
+              version: '3',
+              developmentMode: false,
+            },
+          ],
+        },
+      });
+    });
+
+    it('should update an existing library with the same id', async function () {
+      await runCommand(['add-library', 'mock-library-id', '--libraryVersion', '1', '--symbol', 'MyLib']);
+      await runCommand(['add-library', 'mock-library-id', '--libraryVersion', '2', '--symbol', 'MyLib']);
+
+      const manifest = JSON.parse(fs.readFileSync('appsscript.json', 'utf8'));
+      const libraries = manifest.dependencies.libraries;
+      expect(libraries).to.have.lengthOf(1);
+      expect(libraries[0].version).to.equal('2');
+    });
+
+    it('should add a library as json', async function () {
+      const out = await runCommand([
+        'add-library',
+        'mock-library-id',
+        '--libraryVersion',
+        '3',
+        '--symbol',
+        'MyLib',
+        '--json',
+      ]);
+      const json = JSON.parse(out.stdout);
+      expect(json.success).to.be.true;
+      expect(json.libraryId).to.equal('mock-library-id');
+    });
+  });
+});

--- a/test/commands/program.ts
+++ b/test/commands/program.ts
@@ -23,6 +23,7 @@ import {runCommand} from './utils.js';
 
 describe('Consistency between imported and registered commands', () => {
   const expectedCommands = [
+    'add-library',
     'clone-script',
     'create-deployment',
     'create-script',


### PR DESCRIPTION
Closes #1049

## What
Adds a new `add-library` command that adds a library dependency to the
project's `appsscript.json` manifest, or updates it if a library with
the same `libraryId` is already present.

```
clasp add-library <scriptId> --libraryVersion <version> --symbol <userSymbol> [--dev]
```

## Why
There was no way to add an Apps Script library dependency from the CLI;
the only options were editing `appsscript.json` by hand or using the
web IDE, as noted in #1049.

## Implementation
- `Project.addLibrary()` in `src/core/project.ts` reads the manifest via
  the existing `readManifest()`, upserts the library into
  `dependencies.libraries` (matched by `libraryId`), and writes the file
  back - mirroring the read-modify-write pattern already used by
  `Services.enableService()`/`disableService()`.
- `src/commands/add-library.ts` follows the same structure as
  `enable-api.ts`/`disable-api.ts`.
- Note: the option is named `--libraryVersion` rather than `--version`
  to avoid colliding with the program's global `-v, --version` flag (the
  same reason `create-deployment` uses `--versionNumber` instead of
  `--version`).

## Testing
- Added `test/commands/add-library.ts` covering: adding a new library,
  updating an existing one by `libraryId`, and `--json` output.
- Updated the command registration list in `test/commands/program.ts`.
- `npm run check` (biome + tsc) and `npx mocha` (204 passing) both pass.